### PR TITLE
 Uncomment IgnorePkg if commented (default) when adding a package to IgnorePkg.

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -201,10 +201,10 @@ prompt_to_ignore() {
   local pkg="$1"
   local pacman_conf="${PACMAN_CONF:-/etc/pacman.conf}"
 
-  grep -Eq "^#IgnorePkg" "$pacman_conf" && as_root sed -i "s/^#IgnorePkg/IgnorePkg/" "$pacman_conf"
   grep -Eq "^IgnorePkg.*( |=)$pkg( |$)" "$pacman_conf" && return 0
 
   if prompt_yn $"Add $pkg to IgnorePkg in $pacman_conf"; then
+    grep -Eq "^#IgnorePkg" "$pacman_conf" && as_root sed -i "s/^#IgnorePkg/IgnorePkg/" "$pacman_conf"
     as_root sed -i "s/^IgnorePkg.*/& $pkg/" "$pacman_conf"
   fi
 }


### PR DESCRIPTION
If you try using downgrade to add a package to the IgnorePkg list when said list is commented out (default) downgrade does not add the package to the list. This commit uncomments the IgnorePkg list if the user wants to add a package to said list.
