### PR TITLE
Fix prompt_to_ignore for comment style of emacs.

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -32,7 +32,7 @@ prompt_to_ignore() {
   printf "\n"
 
   if [[ "${ans,,}" == $(gettext 'y')* ]]; then
-    sudo sed -i "s/^#\?\(IgnorePkg.*\)/\1 $pkg/" "$PACMAN_CONF"
+    sudo sed -i "s/^\(# *\)\?\(IgnorePkg.*\)/\2 $pkg/" "$PACMAN_CONF"
   fi
 }
 

--- a/test/prompt_to_ignore.t
+++ b/test/prompt_to_ignore.t
@@ -20,6 +20,13 @@ Uncomments a commented line before adding
   add baz to IgnorePkg? [y/n] 
   IgnorePkg = foo bar baz
 
+  $ echo '# IgnorePkg  = foo' > "$PACMAN_CONF"
+  > echo 'y' | prompt_to_ignore 'baz'
+  > cat "$PACMAN_CONF"
+  
+  add baz to IgnorePkg? [y/n] 
+  IgnorePkg  = foo baz
+
 Does nothing when present
 
   $ echo 'IgnorePkg = foo bar baz' > "$PACMAN_CONF"


### PR DESCRIPTION
By default configuration, emacs will comment "IgnorePkg = foo" to
"# IgnorePkg = foo".
