### PR TITLE
PKGBUILD: Download sources instead of including it into the AUR-tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ pkgver:
 	sed -i "s/^pkgrel=.*/pkgrel=$(RELEASE)/" PKGBUILD
 
 md5sums:
-	sed -i '/^md5sums=.*/,$$d' PKGBUILD
-	makepkg --geninteg --clean >> PKGBUILD
+	updpkgsums
 
 man: $(NAME).8
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,21 +5,15 @@ pkgrel=1
 pkgdesc="Bash script for downgrading one or more packages to a version in your cache or the A.R.M."
 arch=('any')
 url="https://github.com/pbrisbin/$pkgname"
-license="GPL" 
-source=(
-  $pkgname
-  ${pkgname}.8
-  bash_completion
-  zsh_completion
-  fr.po
-  lt.po
-  nb.po
-  nn.po
-  zh_CN.po
-)
+license="GPL"
 optdepends=('sudo: for installation via sudo')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/pbrisbin/$pkgname/archive/v$pkgver.tar.gz")
+md5sums=('e2519b83253cc04eb4c5fba9d3b97215')
+
 
 package() {
+  cd $pkgname-$pkgver
+
   local po_file
 
   for po_file in *.po; do
@@ -34,12 +28,3 @@ package() {
   install -Dm644 bash_completion "$pkgdir/etc/bash_completion.d/downgrade"
   install -Dm644 zsh_completion  "$pkgdir/usr/share/zsh/site-functions/_downgrade"
 }
-md5sums=('e4b6a5a5dde5eac338422451103384ce'
-         '22999424811e44ef287eedb47fd16e27'
-         '38c8fc5c15d36252cb703f568d5a4544'
-         '7dfcbe3c86f264e0cb2f3ad24be6e082'
-         '1cc22667d0af7af8483d85a1586a3a75'
-         'c7b50dde7b06c90dc728f56d374ab22a'
-         'e1f7859463ca1d023a85f3fca5a44454'
-         '0f4ce1ee531eb309c6e31b4153fe4a92'
-         'dd61159825cadb14063998ef3e9b120f')


### PR DESCRIPTION
The following changes the PKGBUILD and the Makefile:

PKGBUILD changes:
- Download tagged downgrade version instead of included source files
- This makes it necessary to enter the downloaded source

Makefile change:
- Use "updpkgsums" instead of "sed + makepkg --geninteg >> PKGBUILD"
  This little program is included with pacman and is doing the same and a bit more.

---

Hi

There it is the PR. I hope everyhing is OK with it

Best regards
