### PR TITLE
checking remote package signatures to fix MitM vulnerability

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -38,6 +38,10 @@ download_when_remote() {
       rm "$pkg"
       return 1
     fi
+    if ! curl --progress-bar "${url}.sig" > "${pkg}.sig"; then
+      rm "$pkg" "${pkg}.sig"
+      return 1
+    fi
   fi
 
   [[ -f "$pkg" ]] && printf "%s" "$pkg"


### PR DESCRIPTION
it would be a great idea to also retrieve the remote signature
file of a package that is downloaded via pure unsecured http.
Without downloading the signature file it is very easy to use a
man-in-the-middle attack to deploy arbitrary files onto the victims
machine.

Maybe also consider creating a new release after this fix :smile: 