### PR TITLE
URL-decode remote package names

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -87,9 +87,10 @@ sort_packages() {
 }
 
 output_package() {
-  printf "%4.4s) %s\n" "$1" "$(
+  printf "%4.4s) %s\n" "$1" "$({
     sed 's|https://.*/\([^/]\+\)$|\1 ('"$(gettext 'remote')"')|;
-         s|^/.*/\([^/]\+\)$|\1 ('"$(gettext 'local')"')|;' <<< "$2")"
+         s|^/.*/\([^/]\+\)$|\1 ('"$(gettext 'local')"')|;
+         s|+| |g;s|%|\\x|' | xargs -0 printf "%b"; } <<< "$2")"
 }
 
 main() {

--- a/test/present_packages.t
+++ b/test/present_packages.t
@@ -15,3 +15,17 @@ Retuns 1 if no arguments were given
 
   $ present_packages
   [1]
+
+URL decodes package names
+
+  $ present_packages \
+  >   python-setuptools-1.0-1-any.pkg.tar.xz \
+  >   python-setuptools-1%3A20.3-1-any.pkg.tar.xz \
+  >   python-setuptools-1%3A20.2.2-1-any.pkg.tar.xz
+  Available packages:
+  
+     1) python-setuptools-1.0-1-any.pkg.tar.xz
+     2) python-setuptools-1:20.3-1-any.pkg.tar.xz
+     3) python-setuptools-1:20.2.2-1-any.pkg.tar.xz
+  
+  select a package by number:  (no-eol)


### PR DESCRIPTION
These names are (effectively) basename of the URLs parsed out of the HTML index
and so are URL-encoded. Decoding them not only looks better but ensures things
sort correctly.