### PR TITLE
Implemented functionality to downgrade to a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Downgrade some packages, checking both local cache and the A.R.M.:
 $ downgrade foo bar
 ```
 
+Downgrade some package to a specific version:
+
+```
+$ downgrade <package> [-v version]
+```
+
 Downgrade a package, looking in only local cache:
 
 ```
@@ -24,7 +30,7 @@ Downgrade a package, looking in only the A.R.M.:
 $ NOCACHE=1 downgrade foo
 ```
 
-Downgrade a package, looking only in local cache, and favoring `su` over 
+Downgrade a package, looking only in local cache, and favoring `su` over
 `sudo` even when `sudo` is available:
 
 ```

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -5,7 +5,7 @@
 .SH SYNOPSIS
 .LP
 .HP
-\fBdowngrade\fR \[lB]PACKAGE, ...\[rB] \[lB]\-\- \[lB]PACMAN OPTIONS\[rB]\[rB]
+\fBdowngrade\fR \[lB]PACKAGE, ...\[rB] \[lB]\-v \<version>\[rB] \[lB]\-\- \[lB]PACMAN OPTIONS\[rB]\[rB]
 .LP
 .SH DESCRIPTION
 .LP
@@ -34,7 +34,7 @@ Effectively,
 \fBfind $caches -name "${pkg}-[0-9R]*.pkg.tar.[gx]z"\fR
 .LP
 .PP
-Where \fB$caches\fR is the list of all \fBCacheDir\fRs as defined in 
+Where \fB$caches\fR is the list of all \fBCacheDir\fRs as defined in
 \fI\[Do]PACMAN\[ru]CONF\fP (commented or not)\.
 .LP
 .SH ENVIRONMENT VARIABLES
@@ -53,7 +53,7 @@ Your pacman configuration file\. Default is \fI\[sl]etc\[sl]pacman\.conf\fP\.
 .LP
 .TP
 \fIARM\[ru]URL\fP
-The location of an A\.R\.M\. server\. Default is 
+The location of an A\.R\.M\. server\. Default is
 \fIhttps:\[sl]\[sl]archive\.archlinux\.org\fP\.
 .LP
 .TP
@@ -66,13 +66,13 @@ Do not search your local cache\. Default is \fI0\fP\.
 .LP
 .TP
 \fINOSUDO\fP
-Do not use \fBsudo(8)\fR even when available, use \fBsu(1)\fR always\. Default 
+Do not use \fBsudo(8)\fR even when available, use \fBsu(1)\fR always\. Default
 is \fI0\fP\.
 .LP
 .SH AUTHOR
 .LP
 .PP
-Patrick Brisbin 
+Patrick Brisbin
 .MT pbrisbin\[at]gmail\.com
 .ME
 .LP

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`downgrade` [PACKAGE, ...] [-- [PACMAN OPTIONS]]
+`downgrade` [PACKAGE, ...] [-v <version>] [-- [PACMAN OPTIONS]]
 
 ## DESCRIPTION
 
@@ -24,7 +24,7 @@ Effectively,
 
   `find $caches -name "${pkg}-[0-9R]*.pkg.tar.[gx]z"`
 
-Where `$caches` is the list of all `CacheDir`s as defined in 
+Where `$caches` is the list of all `CacheDir`s as defined in
 *$PACMAN_CONF* (commented or not).
 
 ## ENVIRONMENT VARIABLES
@@ -39,7 +39,7 @@ Where `$caches` is the list of all `CacheDir`s as defined in
   Your pacman configuration file. Default is */etc/pacman.conf*.
 
 *ARM_URL*
-  The location of an A.R.M. server. Default is 
+  The location of an A.R.M. server. Default is
   *https://archive.archlinux.org*.
 
 *NOARM*
@@ -49,7 +49,7 @@ Where `$caches` is the list of all `CacheDir`s as defined in
   Do not search your local cache. Default is *0*.
 
 *NOSUDO*
-  Do not use `sudo(8)` even when available, use `su(1)` always. Default 
+  Do not use `sudo(8)` even when available, use `su(1)` always. Default
   is *0*.
 
 ## AUTHOR

--- a/downgrade
+++ b/downgrade
@@ -75,12 +75,14 @@ search_packages() {
   ((NOARM)) || \
     curl --fail --silent "$index" | sed '
       /.* href="\('"$1"'.*\(any\|'"$ARCH"'\)\.pkg\.tar\.xz\)".*/!d;
-      s||'"$index"'\1|g; s|+| |g; s|%|\\x|' | xargs -0 printf "%b"
+      s||'"$index"'\1|g; s|+| |g; s|%|\\x|' | xargs -0 printf "%b" | grep "\-$version"
+
+  local version_pattern="${version:-[0-9R]}"
 
   # shellcheck disable=SC2046
   ((NOCACHE)) || \
     find $( sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF" ) \
-      -name "$1-[0-9R]*.pkg.tar.[gx]z"
+      -name "$1-$version_pattern*.pkg.tar.[gx]z"
 }
 
 sort_packages() {
@@ -95,6 +97,14 @@ output_package() {
          s|^/.*/\([^/]\+\)$|\1 ('"$(gettext 'local')"')|;' <<< "$2")"
 }
 
+check_packages() {
+  test "${#candidates[@]}" -gt 1 && present_packages "${candidates[@]}"
+}
+
+check_selection() {
+  test "${#candidates[@]}" -gt 1 && choice="$(read_selection "${candidates[@]}")"
+}
+
 main() {
   local term candidates choice pkg exit_code=0
 
@@ -103,8 +113,8 @@ main() {
   for term; do
     candidates=( $(search_packages "$term" | sort_packages) )
 
-    if present_packages "${candidates[@]}"; then
-      if choice="$(read_selection "${candidates[@]}")"; then
+    if check_packages || test "${#candidates[@]}" -gt 0; then
+      if check_selection || choice="${candidates[0]}"; then
         to_ignore+=( "$term" )
 
         if download_when_remote "$choice"; then
@@ -135,16 +145,18 @@ declare -a terms
 declare -a to_ignore
 declare -a to_install
 declare -a pacman_args
+declare -a version
 
 while [[ -n "$1" ]]; do
   case "$1" in
     --) shift; pacman_args=( "$@" ); break ;;
+    -v) shift; version=( "$1" ); break ;;
     *)  terms+=( "$1" ); shift ;;
   esac
 done
 
 if (( ! "${#terms[@]}" )) && ((!LIB)); then
-  ( gettext 'usage: downgrade <pkg>, ... [-- <pacman options>]'; echo
+  ( gettext 'usage: downgrade <pkg>, ... [-v <version of package>] [-- <pacman options>]'; echo
     gettext 'see downgrade(8) for details.'; echo
   ) >&2
   exit 1


### PR DESCRIPTION
The option [-v <version>] allows to downgrade a package to a specific version. If the version is in cache too you must choose which of them you want (local or remote).

e.g.
    downgrade wpa_supplicant -v 2.3-1 (not installed, it downgrades it directly)
    downgrade wpa_supplicant -v 1:2.6-2 (currently installed, it shows two options)