### PR TITLE
Handle missing CacheDir in pacman.conf

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -87,11 +87,13 @@ search_packages() {
       /.* href="\('"$name-$version"'.*\(any\|'"$ARCH"'\)\.pkg\.tar\.xz\)".*/!d;
       s||'"$index"'\1|g; s|+| |g; s|%|\\x|' | xargs -0 printf "%b"
 
-  cache_dirs=$(sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF")
-  cache_dirs=${cache_dirs:-$PACMAN_CACHE}
+  if ((!NOCACHE)); then
+    cache_dirs=$(sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF")
+    cache_dirs=${cache_dirs:-$PACMAN_CACHE}
 
-  # shellcheck disable=SC2086
-  ((NOCACHE)) || find $cache_dirs -name "$name-$version*.pkg.tar.[gx]z"
+    # shellcheck disable=SC2086
+    find $cache_dirs -name "$name-$version*.pkg.tar.[gx]z"
+  fi
 }
 
 sort_packages() {

--- a/downgrade
+++ b/downgrade
@@ -90,7 +90,7 @@ search_packages() {
   cache_dirs=$(sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF")
   cache_dirs=${cache_dirs:-$PACMAN_CACHE}
 
-  # shellcheck disable=SC2046
+  # shellcheck disable=SC2086
   ((NOCACHE)) || find $cache_dirs -name "$name-$version*.pkg.tar.[gx]z"
 }
 

--- a/downgrade
+++ b/downgrade
@@ -70,7 +70,7 @@ prompt_to_ignore() {
 }
 
 search_packages() {
-  local name version index
+  local name version index cache_dirs
 
   if [[ "$1" =~ -([0-9R].*)$ ]]; then
     version=${BASH_REMATCH[1]}
@@ -87,10 +87,11 @@ search_packages() {
       /.* href="\('"$name-$version"'.*\(any\|'"$ARCH"'\)\.pkg\.tar\.xz\)".*/!d;
       s||'"$index"'\1|g; s|+| |g; s|%|\\x|' | xargs -0 printf "%b"
 
+  cache_dirs=$(sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF")
+  cache_dirs=${cache_dirs:-$PACMAN_CACHE}
+
   # shellcheck disable=SC2046
-  ((NOCACHE)) || \
-    find $( sed '/^#\?CacheDir *= *\(.*\)$/!d;s//\1/' "$PACMAN_CONF" ) \
-      -name "$name-$version*.pkg.tar.[gx]z"
+  ((NOCACHE)) || find $cache_dirs -name "$name-$version*.pkg.tar.[gx]z"
 }
 
 sort_packages() {
@@ -140,6 +141,7 @@ main() {
 ARCH=${ARCH:-$(uname -m)}
 PACMAN="${PACMAN:-pacman}"
 PACMAN_CONF="${PACMAN_CONF:-/etc/pacman.conf}"
+PACMAN_CACHE="${PACMAN_CACHE:-/var/cache/pacman/pkg/}"
 ARM_URL="${ARM_URL:-https://archive.archlinux.org}"
 NOARM=${NOARM:-0}
 NOCACHE=${NOCACHE:-0}

--- a/test/search_cache.t
+++ b/test/search_cache.t
@@ -61,3 +61,18 @@ With a version string included
   $ PACMAN_CONF=$CRAMTMP/pacman.conf NOARM=1 search_packages 'foo-1' | sort
   /tmp/*/cache_3/foo-1.0.pkg.tar.gz (glob)
   /tmp/*/cache_3/foo-1.1.pkg.tar.gz (glob)
+
+With no config option set
+
+  $ mkdir $CRAMTMP/cache_4
+  > touch $CRAMTMP/cache_4/foo-1.0.pkg.tar.gz
+  > touch $CRAMTMP/cache_4/foo-2.0.pkg.tar.gz
+  > touch $CRAMTMP/cache_4/foo-3.5.pkg.tar.xz
+  > touch $CRAMTMP/cache_4/foo-1.1.pkg.tar.gz
+  > touch $CRAMTMP/cache_4/foo-completions-1.1.pkg.tar.gz
+  > rm $CRAMTMP/pacman.conf
+  > touch $CRAMTMP/pacman.conf
+
+  $ PACMAN_CONF=$CRAMTMP/pacman.conf PACMAN_CACHE=$CRAMTMP/cache_4 NOARM=1 search_packages 'foo-1' | sort
+  /tmp/*/cache_4/foo-1.0.pkg.tar.gz (glob)
+  /tmp/*/cache_4/foo-1.1.pkg.tar.gz (glob)


### PR DESCRIPTION
Default to ${PACMAN_CACHE:-/var/cache/pacman/pkg/}

Fixes #47