### PR TITLE
Fixup manpage OUTPUT section

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,11 @@
 engines:
   shellcheck:
     enabled: true
+  markdownlint:
+    enabled: true
+    exclude_paths:
+      - "**/*"
+      - "!**/*.md"
 ratings:
   paths:
   - "downgrade"

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -9,6 +9,53 @@
 .SH DESCRIPTION
 .PP
 Downgrade Arch Linux packages.
+.SH OUTPUT
+.PP
+Just calling \f[C]downgrade package\f[R] will lead to the following
+output:
+.PP
+\f[I]Example:\f[R]
+.IP
+.nf
+\f[C]
+Available packages:
+
+\-   1)  terraform    0.11.11  2  x86_64  (remote)
+\-   2)  terraform    0.11.12  1  x86_64  (local)
++   3)  terraform    0.11.13  1  x86_64  (remote)
++   4)  terraform    0.11.13  1  x86_64  (local)
+\-   5)  terraform    0.12.0   1  x86_64  (remote)
+\-   6)  terraform    0.12.0   1  x86_64  (local)
+    7)  terraform    0.12.1   1  x86_64  (remote)
+
+select a package by number:
+\f[R]
+.fi
+.PP
+The columns have the following meaning:
+.PP
+\f[I]indicator\f[R] Possible values: \-, +
+.PP
+\- indicates, that the version was already once installed.
+.PP
++ indicates the currently installed version.
+.PP
+\f[I]enumeration\f[R] An enumeration of the entries for selection.
+.PP
+\f[I]package name\f[R] The name of the package.
+.PP
+\f[I]package version\f[R] The version of the package in cache or A.L.A.
+.PP
+\f[I]package release\f[R] The release of the package in cache or A.L.A.
+.PP
+\f[I]architecture\f[R] The architecture of the package in cache or
+A.L.A.
+.PP
+\f[I]location\f[R] Possible values: (remote), (local)
+.PP
+If you have already downloaded this version, it will show
+\f[I]local\f[R].
+\f[I]remote\f[R] indicates that the version is available on the A.L.A.
 .SH ENVIRONMENT VARIABLES
 .PP
 \f[I]PACMAN\f[R] The pacman command.

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -32,9 +32,9 @@ The columns have the following meaning:
 
 *indicator*
   Possible values: -, +
-  
+
   \- indicates, that the version was already once installed.
-  
+
   \+ indicates the currently installed version.
 
 *enumeration*
@@ -44,16 +44,15 @@ The columns have the following meaning:
   The name of the package.
 
 *package version*
-  The version of the package as noted in the A.L.A.
+  The version of the package in cache or A.L.A.
 
 *package release*
-  The release of the package as noted in the A.L.A.
+  The release of the package in cache or A.L.A.
 
 *architecture*
-  The architecture of the package as noted in the A.L.A.
+  The architecture of the package in cache or A.L.A.
 
 *location*
-
   Possible values: (remote), (local)
 
   If you have already downloaded this version, it will show *local*.


### PR DESCRIPTION
- Trim whitespace
- Don't specify "in the ALA" for values that also apply to local
- Avoid interpreting \*location\* as a header