### PR TITLE
Use less restrictive package file patterns by fully matching the filename

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -82,22 +82,23 @@ prompt_to_ignore() {
 }
 
 search_packages() {
-  local name version index
+  local name version pkgfile_re index
 
   if [[ "$1" =~ -([0-9R].*)$ ]]; then
-    version=${BASH_REMATCH[1]}
+    version="${BASH_REMATCH[1]}"
     name=${1%-$version}
+    version="$version.*"
   else
-    version='[0-9R]'
+    version="[^-]+-[0-9.]+"
     name=$1
   fi
-
+  pkgfile_re="$name-$version-(any|$DOWNGRADE_ARCH)\\.pkg\\.tar\\.(gz|xz|zst)"
   index="$DOWNGRADE_ALA_URL/packages/${name:0:1}/$name/"
 
   if ((DOWNGRADE_FROM_ALA)); then
-    curl --fail --silent "$index" | sed '
-      /.* href="\('"$name-$version"'.*\(any\|'"$DOWNGRADE_ARCH"'\)\.pkg\.tar\.\(gz\|xz\|zst\)\)".*/!d;
-      s||'"$index"'\1|g; s|+| |g; s|%|\\x|g' | xargs -0 printf "%b"
+    curl --fail --silent "$index" | sed -E '
+      /.* href="('"$pkgfile_re"')".*/!d;
+      s||'"$index"'\1|g; s|\+| |g; s|%|\\x|g' | xargs -0 printf "%b"
   fi
 
   if ((DOWNGRADE_FROM_CACHE)); then
@@ -106,7 +107,7 @@ search_packages() {
     : "${PACMAN_CACHE:=/var/cache/pacman/pkg/}"
 
     # shellcheck disable=SC2086
-    find $PACMAN_CACHE -maxdepth 1 -name "$name-$version*.pkg.tar.*" | grep '\.\(gz\|xz\|zst\)$'
+    find $PACMAN_CACHE -maxdepth 1 -regextype posix-extended -regex ".*/$pkgfile_re"
   fi
 }
 

--- a/test/extract_version/main.t
+++ b/test/extract_version/main.t
@@ -2,17 +2,17 @@
 
 It works on a package with only version
 
-  $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1.pkg.tar.gz'
+  $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1-any.pkg.tar.gz'
   ,1.1,,
 
 It works on a package with epoch:version-release
 
-  $ extract_version_parts foo '/tmp/pacman/cache/foo-7:1.1.pkg.tar.gz'
+  $ extract_version_parts foo '/tmp/pacman/cache/foo-7:1.1-any.pkg.tar.gz'
   7,1.1,,
 
 It works on a package with only version-release
 
-  $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1-4.pkg.tar.gz'
+  $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1-4-any.pkg.tar.gz'
   ,1.1,4,
 
 It works on a package with version-release-arch

--- a/test/extract_version/main.t
+++ b/test/extract_version/main.t
@@ -1,19 +1,14 @@
   $ source "$TESTDIR/../helper.sh"
 
-It works on a package with only version
-
-  $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1-any.pkg.tar.gz'
-  ,1.1,,
-
 It works on a package with epoch:version-release
 
-  $ extract_version_parts foo '/tmp/pacman/cache/foo-7:1.1-any.pkg.tar.gz'
-  7,1.1,,
+  $ extract_version_parts foo '/tmp/pacman/cache/foo-7:1.1-1-any.pkg.tar.gz'
+  7,1.1,1,any
 
 It works on a package with only version-release
 
   $ extract_version_parts foo '/tmp/pacman/cache/foo-1.1-4-any.pkg.tar.gz'
-  ,1.1,4,
+  ,1.1,4,any
 
 It works on a package with version-release-arch
 

--- a/test/search_cache/config-missing.t
+++ b/test/search_cache/config-missing.t
@@ -4,13 +4,13 @@ With no config option set
 
   $ PACMAN_CACHE=$(mktemp -d)
   > touch \
-  >   "$PACMAN_CACHE/foo-1.0.pkg.tar.gz" \
-  >   "$PACMAN_CACHE/foo-2.0.pkg.tar.gz" \
-  >   "$PACMAN_CACHE/foo-3.5.pkg.tar.xz" \
-  >   "$PACMAN_CACHE/foo-1.1.pkg.tar.gz" \
-  >   "$PACMAN_CACHE/foo-completions-1.1.pkg.tar.gz"
+  >   "$PACMAN_CACHE/foo-1.0-any.pkg.tar.gz" \
+  >   "$PACMAN_CACHE/foo-2.0-any.pkg.tar.gz" \
+  >   "$PACMAN_CACHE/foo-3.5-any.pkg.tar.xz" \
+  >   "$PACMAN_CACHE/foo-1.1-any.pkg.tar.gz" \
+  >   "$PACMAN_CACHE/foo-completions-1.1-any.pkg.tar.gz"
   > write_pacman_conf
   > DOWNGRADE_FROM_CACHE=1
   > search_packages 'foo-1' | sort
-  /tmp/*/foo-1.0.pkg.tar.gz (glob)
-  /tmp/*/foo-1.1.pkg.tar.gz (glob)
+  /tmp/*/foo-1.0-any.pkg.tar.gz (glob)
+  /tmp/*/foo-1.1-any.pkg.tar.gz (glob)

--- a/test/search_cache/pacman-conf-multiple.t
+++ b/test/search_cache/pacman-conf-multiple.t
@@ -5,15 +5,15 @@ From multiple directories
   $ cache_1=$(mktemp -d --suffix=.1)
   > cache_2=$(mktemp -d --suffix=.2)
   > touch \
-  >   "$cache_1/foo-1.0.pkg.tar.gz" \
-  >   "$cache_2/foo-2.0.pkg.tar.gz" \
-  >   "$cache_1/foo-3.5.pkg.tar.xz" \
-  >   "$cache_2/foo-1.1.pkg.tar.gz"
+  >   "$cache_1/foo-1.0-any.pkg.tar.gz" \
+  >   "$cache_2/foo-2.0-any.pkg.tar.gz" \
+  >   "$cache_1/foo-3.5-any.pkg.tar.xz" \
+  >   "$cache_2/foo-1.1-any.pkg.tar.gz"
   > write_pacman_conf \
   >   "CacheDir = $cache_1/" \
   >   "CacheDir = $cache_2/"
   > DOWNGRADE_FROM_CACHE=1 search_packages 'foo' | cut -d . -f 3- | sort
-  1/foo-1.0.pkg.tar.gz (glob)
-  1/foo-3.5.pkg.tar.xz (glob)
-  2/foo-1.1.pkg.tar.gz (glob)
-  2/foo-2.0.pkg.tar.gz (glob)
+  1/foo-1.0-any.pkg.tar.gz (glob)
+  1/foo-3.5-any.pkg.tar.xz (glob)
+  2/foo-1.1-any.pkg.tar.gz (glob)
+  2/foo-2.0-any.pkg.tar.gz (glob)

--- a/test/search_cache/pacman-conf-multiple.t
+++ b/test/search_cache/pacman-conf-multiple.t
@@ -5,15 +5,15 @@ From multiple directories
   $ cache_1=$(mktemp -d --suffix=.1)
   > cache_2=$(mktemp -d --suffix=.2)
   > touch \
-  >   "$cache_1/foo-1.0-any.pkg.tar.gz" \
-  >   "$cache_2/foo-2.0-any.pkg.tar.gz" \
-  >   "$cache_1/foo-3.5-any.pkg.tar.xz" \
-  >   "$cache_2/foo-1.1-any.pkg.tar.gz"
+  >   "$cache_1/foo-1.0-1-any.pkg.tar.gz" \
+  >   "$cache_2/foo-2.0-1-any.pkg.tar.gz" \
+  >   "$cache_1/foo-3.5-1-any.pkg.tar.xz" \
+  >   "$cache_2/foo-1.1-1-any.pkg.tar.gz"
   > write_pacman_conf \
   >   "CacheDir = $cache_1/" \
   >   "CacheDir = $cache_2/"
   > DOWNGRADE_FROM_CACHE=1 search_packages 'foo' | cut -d . -f 3- | sort
-  1/foo-1.0-any.pkg.tar.gz (glob)
-  1/foo-3.5-any.pkg.tar.xz (glob)
-  2/foo-1.1-any.pkg.tar.gz (glob)
-  2/foo-2.0-any.pkg.tar.gz (glob)
+  1/foo-1.0-1-any.pkg.tar.gz (glob)
+  1/foo-3.5-1-any.pkg.tar.xz (glob)
+  2/foo-1.1-1-any.pkg.tar.gz (glob)
+  2/foo-2.0-1-any.pkg.tar.gz (glob)

--- a/test/search_cache/pacman-conf-single.t
+++ b/test/search_cache/pacman-conf-single.t
@@ -4,14 +4,14 @@ From a single directory
 
   $ cache=$(mktemp -d)
   > touch \
-  >   "$cache/foo-1.0.pkg.tar.gz" \
-  >   "$cache/foo-2.0.pkg.tar.gz" \
-  >   "$cache/foo-3.5.pkg.tar.xz" \
-  >   "$cache/foo-1.1.pkg.tar.gz" \
-  >   "$cache/foo-completions-1.1.pkg.tar.gz"
+  >   "$cache/foo-1.0-any.pkg.tar.gz" \
+  >   "$cache/foo-2.0-any.pkg.tar.gz" \
+  >   "$cache/foo-3.5-any.pkg.tar.xz" \
+  >   "$cache/foo-1.1-any.pkg.tar.gz" \
+  >   "$cache/foo-completions-1.1-any.pkg.tar.gz"
   > write_pacman_conf "CacheDir = $cache/"
   > DOWNGRADE_FROM_CACHE=1 search_packages 'foo' | sort
-  /tmp/*/foo-1.0.pkg.tar.gz (glob)
-  /tmp/*/foo-1.1.pkg.tar.gz (glob)
-  /tmp/*/foo-2.0.pkg.tar.gz (glob)
-  /tmp/*/foo-3.5.pkg.tar.xz (glob)
+  /tmp/*/foo-1.0-any.pkg.tar.gz (glob)
+  /tmp/*/foo-1.1-any.pkg.tar.gz (glob)
+  /tmp/*/foo-2.0-any.pkg.tar.gz (glob)
+  /tmp/*/foo-3.5-any.pkg.tar.xz (glob)

--- a/test/search_cache/pacman-conf-single.t
+++ b/test/search_cache/pacman-conf-single.t
@@ -4,14 +4,14 @@ From a single directory
 
   $ cache=$(mktemp -d)
   > touch \
-  >   "$cache/foo-1.0-any.pkg.tar.gz" \
-  >   "$cache/foo-2.0-any.pkg.tar.gz" \
-  >   "$cache/foo-3.5-any.pkg.tar.xz" \
-  >   "$cache/foo-1.1-any.pkg.tar.gz" \
-  >   "$cache/foo-completions-1.1-any.pkg.tar.gz"
+  >   "$cache/foo-1.0-1-any.pkg.tar.gz" \
+  >   "$cache/foo-2.0-1-any.pkg.tar.gz" \
+  >   "$cache/foo-3.5-1-any.pkg.tar.xz" \
+  >   "$cache/foo-1.1-1-any.pkg.tar.gz" \
+  >   "$cache/foo-completions-1.1-1-any.pkg.tar.gz"
   > write_pacman_conf "CacheDir = $cache/"
   > DOWNGRADE_FROM_CACHE=1 search_packages 'foo' | sort
-  /tmp/*/foo-1.0-any.pkg.tar.gz (glob)
-  /tmp/*/foo-1.1-any.pkg.tar.gz (glob)
-  /tmp/*/foo-2.0-any.pkg.tar.gz (glob)
-  /tmp/*/foo-3.5-any.pkg.tar.xz (glob)
+  /tmp/*/foo-1.0-1-any.pkg.tar.gz (glob)
+  /tmp/*/foo-1.1-1-any.pkg.tar.gz (glob)
+  /tmp/*/foo-2.0-1-any.pkg.tar.gz (glob)
+  /tmp/*/foo-3.5-1-any.pkg.tar.xz (glob)

--- a/test/search_cache/specific-version.t
+++ b/test/search_cache/specific-version.t
@@ -4,12 +4,12 @@ With a version string included
 
   $ cache=$(mktemp -d)
   > touch \
-  >   "$cache/foo-1.0.pkg.tar.gz" \
-  >   "$cache/foo-2.0.pkg.tar.gz" \
-  >   "$cache/foo-3.5.pkg.tar.xz" \
-  >   "$cache/foo-1.1.pkg.tar.gz" \
-  >   "$cache/foo-completions-1.1.pkg.tar.gz"
+  >   "$cache/foo-1.0-any.pkg.tar.gz" \
+  >   "$cache/foo-2.0-any.pkg.tar.gz" \
+  >   "$cache/foo-3.5-any.pkg.tar.xz" \
+  >   "$cache/foo-1.1-any.pkg.tar.gz" \
+  >   "$cache/foo-completions-1.1-any.pkg.tar.gz"
   > write_pacman_conf "CacheDir = $cache/"
   > DOWNGRADE_FROM_CACHE=1 search_packages 'foo-1' | sort
-  /tmp/*/foo-1.0.pkg.tar.gz (glob)
-  /tmp/*/foo-1.1.pkg.tar.gz (glob)
+  /tmp/*/foo-1.0-any.pkg.tar.gz (glob)
+  /tmp/*/foo-1.1-any.pkg.tar.gz (glob)

--- a/test/sort_packages/by-filename.t
+++ b/test/sort_packages/by-filename.t
@@ -4,8 +4,8 @@ Prepends the filename for the sorting utility
 
   $ pacsort() { cat >&2; }
   > sort_packages >/dev/null << EOF
-  > /tmp/pacman/cache/foo-1.1.pkg.tar.gz
+  > /tmp/pacman/cache/foo-1.1-any.pkg.tar.gz
   > http://repo-arm-download.archlinuxcn.org/extra/os/x86_64/foo-4.0-1-x86_64.pkg.tar.xz
   > EOF
-  foo-1.1.pkg.tar.gz|/tmp/pacman/cache/foo-1.1.pkg.tar.gz
+  foo-1.1-any.pkg.tar.gz|/tmp/pacman/cache/foo-1.1-any.pkg.tar.gz
   foo-4.0-1-x86_64.pkg.tar.xz|http://repo-arm-download.archlinuxcn.org/extra/os/x86_64/foo-4.0-1-x86_64.pkg.tar.xz

--- a/test/sort_packages/omits-testing.t
+++ b/test/sort_packages/omits-testing.t
@@ -3,9 +3,9 @@
 Omits testing entries from remote packages
 
   $ sort_packages << EOF
-  > /tmp/pacman/cache/foo-1.1.pkg.tar.gz
+  > /tmp/pacman/cache/foo-1.1-any.pkg.tar.gz
   > http://repo-arm-download.archlinuxcn.org/testing/os/x86_64/foo-4.0-1-x86_64.pkg.tar.xz
   > http://repo-arm-download.archlinuxcn.org/extra/os/x86_64/foo-4.0-1-x86_64.pkg.tar.xz
   > EOF
-  /tmp/pacman/cache/foo-1.1.pkg.tar.gz
+  /tmp/pacman/cache/foo-1.1-any.pkg.tar.gz
   http://repo-arm-download.archlinuxcn.org/extra/os/x86_64/foo-4.0-1-x86_64.pkg.tar.xz


### PR DESCRIPTION
This fixes #92.

The old behavior is preserved if a version-like string is passed in because there isn't a way to decide if there is a (partial) version or not.

There are still scenarios that downgrade doesn't work but people should find that downgrade works for strictly more package names without any new issues.
