### PR TITLE
Adding command-line arguments for downgrade

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,2 @@
+todos.org
+Peek*

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,2 +1,0 @@
-todos.org
-Peek*

--- a/downgrade
+++ b/downgrade
@@ -213,7 +213,7 @@ process_term() {
   else
     if present_packages "$term" "${candidates[@]}"; then
       choice=$(read_selection "${candidates[@]}")
-      if [ -z "$choice" ]; then
+      if [[ -z "$choice" ]]; then
         {
           gettext "Invalid choice"
           echo

--- a/downgrade
+++ b/downgrade
@@ -214,7 +214,10 @@ process_term() {
     if present_packages "$term" "${candidates[@]}"; then
       choice=$(read_selection "${candidates[@]}")
       if [ -z "$choice" ]; then
-        { gettext "Invalid choice"; echo; } >&2
+        {
+          gettext "Invalid choice"
+          echo
+        } >&2
       fi
     fi
   fi
@@ -280,9 +283,9 @@ cli() {
           PACMAN="$1"
         else
           {
-          gettext "Missing --pacman argument"
-          echo
-          gettext "$(usage)"
+            gettext "Missing --pacman argument"
+            echo
+            gettext "$(usage)"
           } >&2
           exit 1
         fi
@@ -293,9 +296,9 @@ cli() {
           PACMAN_CONF="$1"
         else
           {
-          gettext "Missing --pacman-conf argument"
-          echo
-          gettext "$(usage)"
+            gettext "Missing --pacman-conf argument"
+            echo
+            gettext "$(usage)"
           } >&2
           exit 1
         fi
@@ -306,9 +309,9 @@ cli() {
           DOWNGRADE_ARCH="$1"
         else
           {
-          gettext "Missing --arch argument"
-          echo
-          gettext "$(usage)"
+            gettext "Missing --arch argument"
+            echo
+            gettext "$(usage)"
           } >&2
           exit 1
         fi
@@ -319,9 +322,9 @@ cli() {
           DOWNGRADE_ALA_URL="$1"
         else
           {
-          gettext "Missing --ala-url argument"
-          echo
-          gettext "$(usage)"
+            gettext "Missing --ala-url argument"
+            echo
+            gettext "$(usage)"
           } >&2
           exit 1
         fi
@@ -355,9 +358,9 @@ cli() {
 
   if ((!"${#terms[@]}")); then
     {
-    gettext "No packages provided for downgrading"
-    echo
-    gettext "$(usage)"
+      gettext "No packages provided for downgrading"
+      echo
+      gettext "$(usage)"
     } >&2
     exit 1
   fi

--- a/downgrade
+++ b/downgrade
@@ -211,7 +211,7 @@ process_term() {
     choice=${candidates[0]}
   else
     if present_packages "$term" "${candidates[@]}"; then
-      choice=$(read_selection "${candidates[@]}")
+      choice=$(read_selection "${candidates[@]}") || gettext "Invalid choice"
     fi
   fi
 
@@ -233,10 +233,8 @@ main() {
     # shellcheck disable=SC2207
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
-    process_term "$term" || {
-      exit_code=1
-      gettext "No package with name $term found"
-    }
+    [[ -z "$current" ]] && gettext "No package with name $term found"
+    process_term "$term" || exit_code=1
   done
 
   return $exit_code

--- a/downgrade
+++ b/downgrade
@@ -268,24 +268,48 @@ cli() {
   while [[ -n "$1" ]]; do
     case "$1" in
       --pacman)
-        [[ -n "$2" ]] || (gettext "Missing --pacman argument" && echo && gettext "$(usage)" && exit 1)
-        shift
-        PACMAN="$1"
+        if [[ -n "$2" ]]; then
+          shift
+          PACMAN="$1"
+        else
+          gettext "Missing --pacman argument"
+          echo
+          gettext "$(usage)"
+          exit 1
+        fi
         ;;
       --pacman-conf)
-        [[ -n "$2" ]] || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)" && exit 1)
-        shift
-        PACMAN_CONF="$1"
+        if [[ -n "$2" ]]; then
+          shift
+          PACMAN_CONF="$1"
+        else
+          gettext "Missing --pacman-conf argument"
+          echo
+          gettext "$(usage)"
+          exit 1
+        fi
         ;;
       --arch)
-        [[ -n "$2" ]] || (gettext "Missing --arch argument" && echo && gettext "$(usage)" && exit 1)
-        shift
-        DOWNGRADE_ARCH="$1"
+        if [[ -n "$2" ]]; then
+          shift
+          DOWNGRADE_ARCH="$1"
+        else
+          gettext "Missing --arch argument"
+          echo
+          gettext "$(usage)"
+          exit 1
+        fi
         ;;
       --ala-url)
-        [[ -n "$2" ]] || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)" && exit 1)
-        shift
+        if [[ -n "$2" ]]; then
+          shift
         DOWNGRADE_ALA_URL="$1"
+        else
+          gettext "Missing --ala-url argument"
+          echo
+          gettext "$(usage)"
+          exit 1
+        fi
         ;;
       --ala)
         DOWNGRADE_FROM_ALA=1
@@ -313,11 +337,9 @@ cli() {
   done
 
   if ((!"${#terms[@]}")); then
-    (
-      gettext "No packages provided for downgrading"
-      echo
-      gettext "$(usage)"
-    ) >&2
+    gettext "No packages provided for downgrading"
+    echo
+    gettext "$(usage)"
     exit 1
   fi
 

--- a/downgrade
+++ b/downgrade
@@ -326,8 +326,8 @@ cli() {
         gettext "$(usage)"
         exit 1
         ;;
-      --)
-        ;;
+      --) ;;
+
       -*)
         pacman_args=("$@")
         break

--- a/downgrade
+++ b/downgrade
@@ -260,13 +260,13 @@ cli() {
         [[ -n "$1" ]] && DOWNGRADE_ALA_URL="$1"
         ;;
       --ala)
-        [[ -n "$1" ]] && DOWNGRADE_FROM_ALA=1 && DOWNGRADE_FROM_CACHE=0
+        DOWNGRADE_FROM_ALA=1 && DOWNGRADE_FROM_CACHE=0
         ;;
       --cached)
-        [[ -n "$1" ]] && DOWNGRADE_FROM_ALA=0 && DOWNGRADE_FROM_CACHE=1
+        DOWNGRADE_FROM_ALA=0 && DOWNGRADE_FROM_CACHE=1
         ;;
       --nosudo)
-        [[ -n "$1" ]] && DOWNGRADE_NOSUDO=1
+        DOWNGRADE_NOSUDO=1
         ;;
       -*)
         pacman_args+=("$1")

--- a/downgrade
+++ b/downgrade
@@ -6,8 +6,8 @@ export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
-Usage: downgrade [options] <package>... [-- [pacman_options]]
-       downgrade <package>... [options] [-- [pacman_options]]
+Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]
+       downgrade <pkg> [pkg...] [option...] [-- pacman_option...]
 
   Options:
     --pacman <command>

--- a/downgrade
+++ b/downgrade
@@ -6,7 +6,8 @@ export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
-Usage: downgrade [options] [packages] -- [pacman_options]
+Usage: downgrade [options] <package>... [-- [pacman_options]]
+       downgrade <package>... [options] [-- [pacman_options]]
 
   Options:
     --pacman <command>

--- a/downgrade
+++ b/downgrade
@@ -23,7 +23,7 @@ Usage: downgrade [options] [packages] -- [pacman_options]
     -h, --help      show help script
 
   Note:
-    Any unrecognized options will be assumed as pacman options.
+    Any options after the -- character sequence will be treated as pacman options.
     See "man downgrade" for further details.
 EOF
 }

--- a/downgrade
+++ b/downgrade
@@ -303,7 +303,7 @@ cli() {
       --ala-url)
         if [[ -n "$2" ]]; then
           shift
-        DOWNGRADE_ALA_URL="$1"
+          DOWNGRADE_ALA_URL="$1"
         else
           gettext "Missing --ala-url argument"
           echo

--- a/downgrade
+++ b/downgrade
@@ -260,10 +260,12 @@ cli() {
         [[ -n "$1" ]] && DOWNGRADE_ALA_URL="$1"
         ;;
       --ala)
-        DOWNGRADE_FROM_ALA=1 && DOWNGRADE_FROM_CACHE=0
+        DOWNGRADE_FROM_ALA=1
+        DOWNGRADE_FROM_CACHE=0
         ;;
       --cached)
-        DOWNGRADE_FROM_ALA=0 && DOWNGRADE_FROM_CACHE=1
+        DOWNGRADE_FROM_ALA=0
+        DOWNGRADE_FROM_CACHE=1
         ;;
       --nosudo)
         DOWNGRADE_NOSUDO=1

--- a/downgrade
+++ b/downgrade
@@ -206,7 +206,6 @@ process_term() {
   local term=$1 candidates choice
 
   candidates=($(search_packages "$term" | sort_packages))
-  [ ${#candidates[@]} -eq 0 ] && gettext "No package with name $term found" && echo && gettext "$(usage)"
 
   if (("${#candidates[@]}" == 1)); then
     choice=${candidates[0]}
@@ -321,7 +320,9 @@ cli() {
     }
   fi
 
-  main "${terms[@]}"
+  for term in "${terms[@]}"; do
+    main "$term" || (gettext "No package with name $term found" && echo && gettext "$(usage)" && exit 1)
+  done
   sudo pacman -U "${pacman_args[@]}" "${to_install[@]}"
   prompt_to_ignore "${to_ignore[@]}"
 }

--- a/downgrade
+++ b/downgrade
@@ -206,7 +206,7 @@ process_term() {
   local term=$1 candidates choice
 
   candidates=($(search_packages "$term" | sort_packages))
-  [ ${#candidates[@]} -eq 0 ] && gettext "No package with name $term found" && echo && gettext "$(usage)" && exit 1
+  [ ${#candidates[@]} -eq 0 ] && gettext "No package with name $term found" && echo && gettext "$(usage)"
 
   if (("${#candidates[@]}" == 1)); then
     choice=${candidates[0]}

--- a/downgrade
+++ b/downgrade
@@ -7,7 +7,6 @@ export TEXTDOMAINDIR=/usr/share/locale
 usage() {
   cat <<EOF
 Usage: downgrade [option...] <pkg> [pkg...] [-- [pacman_option...]]
-       downgrade <pkg> [pkg...] [option...] [-- [pacman_option...]]
 
   Options:
     --pacman <command>

--- a/downgrade
+++ b/downgrade
@@ -233,7 +233,10 @@ main() {
     # shellcheck disable=SC2207
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
-    process_term "$term" || { exit_code=1; gettext "No package with name $term found"; }
+    process_term "$term" || {
+      exit_code=1
+      gettext "No package with name $term found"
+    }
   done
 
   return $exit_code

--- a/downgrade
+++ b/downgrade
@@ -268,16 +268,24 @@ cli() {
   while [[ -n "$1" ]]; do
     case "$1" in
       --pacman)
-        [[ -n "$2" ]] && shift && PACMAN="$1" || (gettext "Missing --pacman argument" && echo && gettext "$(usage)" && exit 1)
+        [[ -n "$2" ]] || (gettext "Missing --pacman argument" && echo && gettext "$(usage)" && exit 1)
+        shift
+        PACMAN="$1"
         ;;
       --pacman-conf)
-        [[ -n "$2" ]] && shift && PACMAN_CONF="$1" || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)" && exit 1)
+        [[ -n "$2" ]] || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)" && exit 1)
+        shift
+        PACMAN_CONF="$1"
         ;;
       --arch)
-        [[ -n "$2" ]] && shift && DOWNGRADE_ARCH="$1" || (gettext "Missing --arch argument" && echo && gettext "$(usage)" && exit 1)
+        [[ -n "$2" ]] || (gettext "Missing --arch argument" && echo && gettext "$(usage)" && exit 1)
+        shift
+        DOWNGRADE_ARCH="$1"
         ;;
       --ala-url)
-        [[ -n "$2" ]] && shift && DOWNGRADE_ALA_URL="$1" || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)" && exit 1)
+        [[ -n "$2" ]] || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)" && exit 1)
+        shift
+        DOWNGRADE_ALA_URL="$1"
         ;;
       --ala)
         DOWNGRADE_FROM_ALA=1

--- a/downgrade
+++ b/downgrade
@@ -268,16 +268,16 @@ cli() {
   while [[ -n "$1" ]]; do
     case "$1" in
       --pacman)
-        ([[ -n "$2" ]] && shift && PACMAN="$1") || (gettext "Missing --pacman argument" && echo && gettext "$(usage)")
+        [[ -n "$2" ]] && shift && PACMAN="$1" || (gettext "Missing --pacman argument" && echo && gettext "$(usage)" && exit 1)
         ;;
       --pacman-conf)
-        ([[ -n "$2" ]] && shift && PACMAN_CONF="$1") || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)")
+        [[ -n "$2" ]] && shift && PACMAN_CONF="$1" || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)" && exit 1)
         ;;
       --arch)
-        ([[ -n "$2" ]] && shift && DOWNGRADE_ARCH="$1") || (gettext "Missing --arch argument" && echo && gettext "$(usage)")
+        [[ -n "$2" ]] && shift && DOWNGRADE_ARCH="$1" || (gettext "Missing --arch argument" && echo && gettext "$(usage)" && exit 1)
         ;;
       --ala-url)
-        ([[ -n "$2" ]] && shift && DOWNGRADE_ALA_URL="$1") || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)")
+        [[ -n "$2" ]] && shift && DOWNGRADE_ALA_URL="$1" || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)" && exit 1)
         ;;
       --ala)
         DOWNGRADE_FROM_ALA=1

--- a/downgrade
+++ b/downgrade
@@ -214,7 +214,7 @@ process_term() {
     if present_packages "$term" "${candidates[@]}"; then
       choice=$(read_selection "${candidates[@]}")
       if [ -z "$choice" ]; then
-        ( gettext "Invalid choice" && echo ) >&2
+        { gettext "Invalid choice"; echo; } >&2
       fi
     fi
   fi
@@ -238,7 +238,7 @@ main() {
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
     if ! process_term "$term"; then
-      ( gettext "Unable to downgrade $term" ) >&2
+      gettext "Unable to downgrade $term" >&2
       exit_code=1
     fi
   done
@@ -279,11 +279,11 @@ cli() {
           shift
           PACMAN="$1"
         else
-          (
+          {
           gettext "Missing --pacman argument"
           echo
           gettext "$(usage)"
-          ) >&2
+          } >&2
           exit 1
         fi
         ;;
@@ -292,11 +292,11 @@ cli() {
           shift
           PACMAN_CONF="$1"
         else
-          (
+          {
           gettext "Missing --pacman-conf argument"
           echo
           gettext "$(usage)"
-          ) >&2
+          } >&2
           exit 1
         fi
         ;;
@@ -305,11 +305,11 @@ cli() {
           shift
           DOWNGRADE_ARCH="$1"
         else
-          (
+          {
           gettext "Missing --arch argument"
           echo
           gettext "$(usage)"
-          ) >&2
+          } >&2
           exit 1
         fi
         ;;
@@ -318,11 +318,11 @@ cli() {
           shift
           DOWNGRADE_ALA_URL="$1"
         else
-          (
+          {
           gettext "Missing --ala-url argument"
           echo
           gettext "$(usage)"
-          ) >&2
+          } >&2
           exit 1
         fi
         ;;
@@ -354,11 +354,11 @@ cli() {
   done
 
   if ((!"${#terms[@]}")); then
-    (
+    {
     gettext "No packages provided for downgrading"
     echo
     gettext "$(usage)"
-    ) >&2
+    } >&2
     exit 1
   fi
 

--- a/downgrade
+++ b/downgrade
@@ -233,8 +233,10 @@ main() {
     # shellcheck disable=SC2207
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
-    [[ -z "$current" ]] && gettext "No package with name $term found"
-    process_term "$term" || exit_code=1
+    if ! process_term "$term"; then
+      gettext "Unable to downgrade $term"
+      exit_code=1
+    fi
   done
 
   return $exit_code

--- a/downgrade
+++ b/downgrade
@@ -243,16 +243,39 @@ declare -a installed
 cli() {
   while [[ -n "$1" ]]; do
     case "$1" in
-      --)
+      --pacman)
         shift
-        pacman_args=("$@")
-        break
+        [[ -n "$1" ]] && PACMAN="$1"
+        ;;
+      --pacman-conf)
+        shift
+        [[ -n "$1" ]] && PACMAN_CONF="$1"
+        ;;
+      --arch)
+        shift
+        [[ -n "$1" ]] && DOWNGRADE_ARCH="$1"
+        ;;
+      --ala-url)
+        shift
+        [[ -n "$1" ]] && DOWNGRADE_ALA_URL="$1"
+        ;;
+      --ala)
+        [[ -n "$1" ]] && DOWNGRADE_FROM_ALA=1 && DOWNGRADE_FROM_CACHE=0
+        ;;
+      --cached)
+        [[ -n "$1" ]] && DOWNGRADE_FROM_ALA=0 && DOWNGRADE_FROM_CACHE=1
+        ;;
+      --nosudo)
+        [[ -n "$1" ]] && DOWNGRADE_NOSUDO=1
+        ;;
+      -*)
+        pacman_args+=("$1")
         ;;
       *)
         terms+=("$1")
-        shift
         ;;
     esac
+    shift
   done
 
   if ((!"${#terms[@]}")); then

--- a/downgrade
+++ b/downgrade
@@ -6,7 +6,7 @@ export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
-Usage: downgrade [options] [pacman_options] [packages]
+Usage: downgrade [options] [packages] [pacman_options]
 
   Options:
     --pacman <command>
@@ -326,8 +326,11 @@ cli() {
         gettext "$(usage)"
         exit 1
         ;;
+      --)
+        ;;
       -*)
-        pacman_args+=("$1")
+        pacman_args=("$@")
+        break
         ;;
       *)
         terms+=("$1")

--- a/downgrade
+++ b/downgrade
@@ -6,7 +6,7 @@ export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
-Usage: downgrade [options] [packages] [pacman_options]
+Usage: downgrade [options] [packages] -- [pacman_options]
 
   Options:
     --pacman <command>
@@ -17,8 +17,8 @@ Usage: downgrade [options] [packages] [pacman_options]
                     target architecture, defaults to output of "uname -m"
     --ala-url <url>
                     location of ALA server, defaults to "https://archive.archlinux.org"
-    --ala           only use ALA server
-    --cached        only use cached packages
+    --ala-only      only use ALA server
+    --cached-only   only use cached packages
     --nosudo        do not use sudo, even when available
     -h, --help      show help script
 
@@ -233,7 +233,7 @@ main() {
     # shellcheck disable=SC2207
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
-    process_term "$term" || exit_code=1
+    process_term "$term" || { exit_code=1; gettext "No package with name $term found"; }
   done
 
   return $exit_code
@@ -326,9 +326,8 @@ cli() {
         gettext "$(usage)"
         exit 1
         ;;
-      --) ;;
-
-      -*)
+      --)
+        shift
         pacman_args=("$@")
         break
         ;;
@@ -353,9 +352,7 @@ cli() {
     }
   fi
 
-  for term in "${terms[@]}"; do
-    main "$term" || (gettext "No package with name $term found" && echo && gettext "$(usage)" && exit 1)
-  done
+  main "${terms[@]}"
   sudo pacman -U "${pacman_args[@]}" "${to_install[@]}"
   prompt_to_ignore "${to_ignore[@]}"
 }

--- a/downgrade
+++ b/downgrade
@@ -26,7 +26,7 @@ Usage: downgrade [options] [pacman_options] [packages]
     Any unrecognized options will be assumed as pacman options.
     See "man downgrade" for further details.
 EOF
-  }
+}
 
 read_pacman_conf() { sed '/^#\?'"$1"' *= *\(.*\)$/!d; s//\1/' "$PACMAN_CONF"; }
 
@@ -290,7 +290,7 @@ cli() {
       --nosudo)
         DOWNGRADE_NOSUDO=1
         ;;
-      -h|--help)
+      -h | --help)
         gettext "$(usage)"
         exit 1
         ;;

--- a/downgrade
+++ b/downgrade
@@ -6,8 +6,8 @@ export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
-Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]
-       downgrade <pkg> [pkg...] [option...] [-- pacman_option...]
+Usage: downgrade [option...] <pkg> [pkg...] [-- [pacman_option...]]
+       downgrade <pkg> [pkg...] [option...] [-- [pacman_option...]]
 
   Options:
     --pacman <command>

--- a/downgrade
+++ b/downgrade
@@ -212,7 +212,10 @@ process_term() {
     choice=${candidates[0]}
   else
     if present_packages "$term" "${candidates[@]}"; then
-      choice=$(read_selection "${candidates[@]}") || gettext "Invalid choice"
+      choice=$(read_selection "${candidates[@]}")
+      if [ -z "$choice" ]; then
+        ( gettext "Invalid choice" && echo ) >&2
+      fi
     fi
   fi
 
@@ -235,7 +238,7 @@ main() {
     installed=($(previously_installed "$term"))
     current=$(currently_installed "$term")
     if ! process_term "$term"; then
-      gettext "Unable to downgrade $term"
+      ( gettext "Unable to downgrade $term" ) >&2
       exit_code=1
     fi
   done
@@ -276,9 +279,11 @@ cli() {
           shift
           PACMAN="$1"
         else
+          (
           gettext "Missing --pacman argument"
           echo
           gettext "$(usage)"
+          ) >&2
           exit 1
         fi
         ;;
@@ -287,9 +292,11 @@ cli() {
           shift
           PACMAN_CONF="$1"
         else
+          (
           gettext "Missing --pacman-conf argument"
           echo
           gettext "$(usage)"
+          ) >&2
           exit 1
         fi
         ;;
@@ -298,9 +305,11 @@ cli() {
           shift
           DOWNGRADE_ARCH="$1"
         else
+          (
           gettext "Missing --arch argument"
           echo
           gettext "$(usage)"
+          ) >&2
           exit 1
         fi
         ;;
@@ -309,9 +318,11 @@ cli() {
           shift
           DOWNGRADE_ALA_URL="$1"
         else
+          (
           gettext "Missing --ala-url argument"
           echo
           gettext "$(usage)"
+          ) >&2
           exit 1
         fi
         ;;
@@ -343,9 +354,11 @@ cli() {
   done
 
   if ((!"${#terms[@]}")); then
+    (
     gettext "No packages provided for downgrading"
     echo
     gettext "$(usage)"
+    ) >&2
     exit 1
   fi
 

--- a/downgrade
+++ b/downgrade
@@ -4,6 +4,30 @@
 export TEXTDOMAIN=downgrade
 export TEXTDOMAINDIR=/usr/share/locale
 
+usage() {
+  cat <<EOF
+Usage: downgrade [options] [pacman_options] [packages]
+
+  Options:
+    --pacman <command>
+                    pacman command to use, defaults to "pacman"
+    --pacman-conf <directory>
+                    pacman configuration file, defaults to "/etc/pacman.conf"
+    --arch <architecture>
+                    target architecture, defaults to output of "uname -m"
+    --ala-url <url>
+                    location of ALA server, defaults to "https://archive.archlinux.org"
+    --ala           only use ALA server
+    --cached        only use cached packages
+    --nosudo        do not use sudo, even when available
+    -h, --help      show help script
+
+  Note:
+    Any unrecognized options will be assumed as pacman options.
+    See "man downgrade" for further details.
+EOF
+  }
+
 read_pacman_conf() { sed '/^#\?'"$1"' *= *\(.*\)$/!d; s//\1/' "$PACMAN_CONF"; }
 
 previously_installed() {
@@ -182,6 +206,7 @@ process_term() {
   local term=$1 candidates choice
 
   candidates=($(search_packages "$term" | sort_packages))
+  [ ${#candidates[@]} -eq 0 ] && gettext "No package with name $term found" && echo && gettext "$(usage)" && exit 1
 
   if (("${#candidates[@]}" == 1)); then
     choice=${candidates[0]}
@@ -244,20 +269,16 @@ cli() {
   while [[ -n "$1" ]]; do
     case "$1" in
       --pacman)
-        shift
-        [[ -n "$1" ]] && PACMAN="$1"
+        ([[ -n "$2" ]] && shift && PACMAN="$1") || (gettext "Missing --pacman argument" && echo && gettext "$(usage)")
         ;;
       --pacman-conf)
-        shift
-        [[ -n "$1" ]] && PACMAN_CONF="$1"
+        ([[ -n "$2" ]] && shift && PACMAN_CONF="$1") || (gettext "Missing --pacman-conf argument" && echo && gettext "$(usage)")
         ;;
       --arch)
-        shift
-        [[ -n "$1" ]] && DOWNGRADE_ARCH="$1"
+        ([[ -n "$2" ]] && shift && DOWNGRADE_ARCH="$1") || (gettext "Missing --arch argument" && echo && gettext "$(usage)")
         ;;
       --ala-url)
-        shift
-        [[ -n "$1" ]] && DOWNGRADE_ALA_URL="$1"
+        ([[ -n "$2" ]] && shift && DOWNGRADE_ALA_URL="$1") || (gettext "Missing --ala-url argument" && echo && gettext "$(usage)")
         ;;
       --ala)
         DOWNGRADE_FROM_ALA=1
@@ -269,6 +290,10 @@ cli() {
         ;;
       --nosudo)
         DOWNGRADE_NOSUDO=1
+        ;;
+      -h|--help)
+        gettext "$(usage)"
+        exit 1
         ;;
       -*)
         pacman_args+=("$1")
@@ -282,10 +307,9 @@ cli() {
 
   if ((!"${#terms[@]}")); then
     (
-      gettext 'usage: downgrade <pkg> [pkg...] [-- pacman_option...]'
+      gettext "No packages provided for downgrading"
       echo
-      gettext 'see downgrade(8) for details.'
-      echo
+      gettext "$(usage)"
     ) >&2
     exit 1
   fi

--- a/test/main/invalid-choice.t
+++ b/test/main/invalid-choice.t
@@ -4,7 +4,7 @@
 It does nothing on an invalid choice
 
   $ search_packages() { printf "%s\n" foo foo foo; }
-  > main foo < <(echo -1); exit_code=$?
+  > main foo < <(echo -1) 2>/dev/null; exit_code=$?
   > echo
   > printf "ignore: %s\n" "${to_ignore[@]}"
   > printf "install: %s\n" "${to_install[@]}"

--- a/test/main/no-candidates.t
+++ b/test/main/no-candidates.t
@@ -4,7 +4,7 @@
 It does nothing if there are no candidates
 
   $ search_packages() { :; }
-  > main foo; exit_code=$?
+  > main foo 2>/dev/null; exit_code=$?
   > printf "ignore: %s\n" "${to_ignore[@]}"
   > printf "install: %s\n" "${to_install[@]}"
   > printf "exit code: %s\n" "$exit_code"


### PR DESCRIPTION
Hi @pbrisbin, finally got some time to work on the pull requests. In this PR, I added CLI arguments that can be parsed and used either directly in `downgrade` or by `pacman`. I used the same flow as per `aurget`, as per your recommendation. The previous environmental variables will still work if they are fed in.

Additionally, I added a helper/usage script that can be seen by executing `downgrade --help`. This script also pops up when there are error messages encountered. I added error-based message popups for cases where arguments are wrongly supplied, when packages are not supplied or when supplied packages are missing in the supposed caches/servers

If these changes are fine, I can update the readme and the man-page documentation.