### PR TITLE
Typo in man-page and readme update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,89 @@
-## [*Unreleased*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...master)
+## [*Ongoing*](https://github.com/pbrisbin/downgrade/compare/v6.3.0...master)
+
+- [NEW] Handling hard dependencies during downgrading
+
+## [v6.0.0](https://github.com/pbrisbin/downgrade/compare/v5.4.0...v6.0.0)
+
+- [NEW] Render results one page at a time
+- [NEW] Render an asterisk next to previously-installed versions
+- [NEW] Prefix most configuration variables with `DOWNGRADE_`
+- [FIX] Fix conversion of legacy `ARM_` variables
+- [NEW] Default missing `CacheDir` sensibly
+- [NEW] Download packages to system cache directory
+
+## [v5.4.0](https://github.com/pbrisbin/downgrade/compare/v5.3.0...v5.4.0)
+
+- [FIX] `ARM_URL` in documentation (@andrewcchen)
+- [NEW] Spanish translation (@miachm)
+- [NEW] Russian translation (@7up4)
+- [NEW] Accept version in search term and avoid prompting
+
+## [v5.3.0](https://github.com/pbrisbin/downgrade/compare/v5.2.3...v5.3.0)
+
+- [FIX] Sort using `pacsort`
+- [FIX] Correctly append to `pacman.conf` when `IgnorePkg` not present
+- [FIX] Correctly find packages in A.R.M HTML content
+
+## [v5.2.3](https://github.com/pbrisbin/downgrade/compare/v5.2.2...v5.2.3)
+
+- [FIX] Handling of `+` in URL-decoding
+
+## [v5.2.2](https://github.com/pbrisbin/downgrade/compare/v5.2.1...v5.2.2)
+
+- [NEW] URL-decode package names
+
+## [v5.2.1](https://github.com/pbrisbin/downgrade/compare/v5.2.0...v5.2.1)
+
+- [FIX] Also search for `-any` packages
+
+
+
+## [*v6.3.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.3.0)
+
+- [NEW] Replace environmental variables with command-line options/arguments to alter behaviour
+- [NEW] Locale updates for new behaviour keys
+
+## [v6.0.0](https://github.com/pbrisbin/downgrade/compare/v5.4.0...v6.0.0)
+
+- [NEW] Render results one page at a time
+- [NEW] Render an asterisk next to previously-installed versions
+- [NEW] Prefix most configuration variables with `DOWNGRADE_`
+- [FIX] Fix conversion of legacy `ARM_` variables
+- [NEW] Default missing `CacheDir` sensibly
+- [NEW] Download packages to system cache directory
+
+## [v5.4.0](https://github.com/pbrisbin/downgrade/compare/v5.3.0...v5.4.0)
+
+- [FIX] `ARM_URL` in documentation (@andrewcchen)
+- [NEW] Spanish translation (@miachm)
+- [NEW] Russian translation (@7up4)
+- [NEW] Accept version in search term and avoid prompting
+
+## [v5.3.0](https://github.com/pbrisbin/downgrade/compare/v5.2.3...v5.3.0)
+
+- [FIX] Sort using `pacsort`
+- [FIX] Correctly append to `pacman.conf` when `IgnorePkg` not present
+- [FIX] Correctly find packages in A.R.M HTML content
+
+## [v5.2.3](https://github.com/pbrisbin/downgrade/compare/v5.2.2...v5.2.3)
+
+- [FIX] Handling of `+` in URL-decoding
+
+## [v5.2.2](https://github.com/pbrisbin/downgrade/compare/v5.2.1...v5.2.2)
+
+- [NEW] URL-decode package names
+
+## [v5.2.1](https://github.com/pbrisbin/downgrade/compare/v5.2.0...v5.2.1)
+
+- [FIX] Also search for `-any` packages
+
+## [v5.2.0](https://github.com/pbrisbin/downgrade/compare/v5.1.5...v5.2.0)
+
+- [FIX] Stop outputting corrupt `curl` progress
+- [FIX] Don't rely on repo-arm.archlinuxcn.org
+
+
+## [*v6.1.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...master)
 
 - [NEW] Render "+" for currently installed, "-" for previously installed
   (@Thomaash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,88 +2,12 @@
 
 - [NEW] Handling hard dependencies during downgrading
 
-## [v6.0.0](https://github.com/pbrisbin/downgrade/compare/v5.4.0...v6.0.0)
+## [*v6.3.0*](https://github.com/pbrisbin/downgrade/compare/v6.1.0...v6.3.0)
 
-- [NEW] Render results one page at a time
-- [NEW] Render an asterisk next to previously-installed versions
-- [NEW] Prefix most configuration variables with `DOWNGRADE_`
-- [FIX] Fix conversion of legacy `ARM_` variables
-- [NEW] Default missing `CacheDir` sensibly
-- [NEW] Download packages to system cache directory
+- [NEW] Replace environmental variables with command line arguments/options
+- [NEW] Updating locales to reflect new keys
 
-## [v5.4.0](https://github.com/pbrisbin/downgrade/compare/v5.3.0...v5.4.0)
-
-- [FIX] `ARM_URL` in documentation (@andrewcchen)
-- [NEW] Spanish translation (@miachm)
-- [NEW] Russian translation (@7up4)
-- [NEW] Accept version in search term and avoid prompting
-
-## [v5.3.0](https://github.com/pbrisbin/downgrade/compare/v5.2.3...v5.3.0)
-
-- [FIX] Sort using `pacsort`
-- [FIX] Correctly append to `pacman.conf` when `IgnorePkg` not present
-- [FIX] Correctly find packages in A.R.M HTML content
-
-## [v5.2.3](https://github.com/pbrisbin/downgrade/compare/v5.2.2...v5.2.3)
-
-- [FIX] Handling of `+` in URL-decoding
-
-## [v5.2.2](https://github.com/pbrisbin/downgrade/compare/v5.2.1...v5.2.2)
-
-- [NEW] URL-decode package names
-
-## [v5.2.1](https://github.com/pbrisbin/downgrade/compare/v5.2.0...v5.2.1)
-
-- [FIX] Also search for `-any` packages
-
-
-
-## [*v6.3.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.3.0)
-
-- [NEW] Replace environmental variables with command-line options/arguments to alter behaviour
-- [NEW] Locale updates for new behaviour keys
-
-## [v6.0.0](https://github.com/pbrisbin/downgrade/compare/v5.4.0...v6.0.0)
-
-- [NEW] Render results one page at a time
-- [NEW] Render an asterisk next to previously-installed versions
-- [NEW] Prefix most configuration variables with `DOWNGRADE_`
-- [FIX] Fix conversion of legacy `ARM_` variables
-- [NEW] Default missing `CacheDir` sensibly
-- [NEW] Download packages to system cache directory
-
-## [v5.4.0](https://github.com/pbrisbin/downgrade/compare/v5.3.0...v5.4.0)
-
-- [FIX] `ARM_URL` in documentation (@andrewcchen)
-- [NEW] Spanish translation (@miachm)
-- [NEW] Russian translation (@7up4)
-- [NEW] Accept version in search term and avoid prompting
-
-## [v5.3.0](https://github.com/pbrisbin/downgrade/compare/v5.2.3...v5.3.0)
-
-- [FIX] Sort using `pacsort`
-- [FIX] Correctly append to `pacman.conf` when `IgnorePkg` not present
-- [FIX] Correctly find packages in A.R.M HTML content
-
-## [v5.2.3](https://github.com/pbrisbin/downgrade/compare/v5.2.2...v5.2.3)
-
-- [FIX] Handling of `+` in URL-decoding
-
-## [v5.2.2](https://github.com/pbrisbin/downgrade/compare/v5.2.1...v5.2.2)
-
-- [NEW] URL-decode package names
-
-## [v5.2.1](https://github.com/pbrisbin/downgrade/compare/v5.2.0...v5.2.1)
-
-- [FIX] Also search for `-any` packages
-
-## [v5.2.0](https://github.com/pbrisbin/downgrade/compare/v5.1.5...v5.2.0)
-
-- [FIX] Stop outputting corrupt `curl` progress
-- [FIX] Don't rely on repo-arm.archlinuxcn.org
-
-
-## [*v6.1.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...master)
+## [*v6.1.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.1.0)
 
 - [NEW] Render "+" for currently installed, "-" for previously installed
   (@Thomaash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Downgrade
 
 [![CircleCI](https://circleci.com/gh/pbrisbin/downgrade.svg?style=shield)](https://circleci.com/gh/pbrisbin/downgrade)
+[![gitlocalized ](https://gitlocalize.com/repo/4232/whole_project/badge.svg)](https://gitlocalize.com/repo/4232/whole_project?utm_source=badge)
 
 Eases downgrading packages in Arch Linux.
 

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -135,7 +135,7 @@ By default, \f[B]downgrade\f[R] will search both local caches and the
 ALA.
 .PP
 The package cache directory is read from the pacman configuration file
-by default, or set to \f[I]/var/pacman/pkg/\f[R] when not found.
+by default, or set to \f[I]/var/cache/pacman/pkg/\f[R] when not found.
 .PP
 The pacman log file is read from the pacman configuration file by
 default, or set to \f[I]/var/log/pacman.log\f[R] when not found.

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -98,7 +98,7 @@ As per the usage syntax, any options supplied after the **\--** character sequen
 
 By default, **downgrade** will search both local caches and the ALA.
 
-The package cache directory is read from the pacman configuration file by default, or set to */var/pacman/pkg/* when not found.
+The package cache directory is read from the pacman configuration file by default, or set to */var/cache/pacman/pkg/* when not found.
 
 The pacman log file is read from the pacman configuration file by default, or set to */var/log/pacman.log* when not found.
 


### PR DESCRIPTION
Just realized there was a typo in the readme regarding the cache file path. Also, just added the `gitlocalize` badge to our readme, just so users could know that we offer multilingual scripts.

Would it be fine if I squash merged these to master?