### PR TITLE
Respect PREFIX in locale files' installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/*.t.err
+locale/*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Ongoing](https://github.com/pbrisbin/downgrade/compare/v6.3.0...master)
 
 - [NEW] Handling hard dependencies during downgrading
+- [FIX] Respect PREFIX when installing locale files
 
 ## [v6.3.0](https://github.com/pbrisbin/downgrade/compare/v6.1.0...v6.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-## [*Ongoing*](https://github.com/pbrisbin/downgrade/compare/v6.3.0...master)
+## [Ongoing](https://github.com/pbrisbin/downgrade/compare/v6.3.0...master)
 
 - [NEW] Handling hard dependencies during downgrading
 
-## [*v6.3.0*](https://github.com/pbrisbin/downgrade/compare/v6.1.0...v6.3.0)
+## [v6.3.0](https://github.com/pbrisbin/downgrade/compare/v6.1.0...v6.3.0)
 
 - [NEW] Replace environmental variables with command line arguments/options
 - [NEW] Updating locales to reflect new keys
 
-## [*v6.1.0*](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.1.0)
+## [v6.1.0](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.1.0)
 
 - [NEW] Render "+" for currently installed, "-" for previously installed
   (@Thomaash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [v6.3.0](https://github.com/pbrisbin/downgrade/compare/v6.1.0...v6.3.0)
 
 - [NEW] Replace environmental variables with command line arguments/options
-- [NEW] Updating locales to reflect new keys
+- [FIX] Updating locales to reflect new keys
 
 ## [v6.1.0](https://github.com/pbrisbin/downgrade/compare/v6.0.0...v6.1.0)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-PREFIX    ?= /usr/local
-MANPREFIX ?= $(PREFIX)/share/man
-PANDOC    ?= $(shell which pandoc)
+PREFIX       ?= /usr/local
+LOCALEPREFIX ?= $(PREFIX)/share/locale
+MANPREFIX    ?= $(PREFIX)/share/man
+PANDOC       ?= $(shell which pandoc)
 
 setup:
 	command -v cram   || aurget cram
@@ -27,12 +28,18 @@ install:
 	install -Dm644 doc/downgrade.8 $(DESTDIR)$(MANPREFIX)/man8/downgrade.8
 	install -Dm644 completion/bash $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade
 	install -Dm644 completion/zsh $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade
+	for po_file in locale/*.po; do \
+	  locale="$$(basename "$$po_file" .po)"; \
+	  mkdir -p "$(DESTDIR)$(LOCALEPREFIX)/$$locale/LC_MESSAGES/"; \
+	  msgfmt "$$po_file" -o "$(DESTDIR)$(LOCALEPREFIX)/$$locale/LC_MESSAGES/downgrade.mo"; \
+	done
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/downgrade \
 	  $(DESTDIR)$(MANPREFIX)/man8/downgrade.8 \
 	  $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade \
-	  $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade
+	  $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade \
+	  $(DESTDIR)$(LOCALEPREFIX)/*/LC_MESSAGES/downgrade.mo
 
 .PHONY: setup test install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ install:
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/downgrade \
 	  $(DESTDIR)$(MANPREFIX)/man8/downgrade.8 \
-	  $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade
+	  $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade \
+	  $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade
 
 .PHONY: setup test install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,15 @@ test:
 	cram test
 
 install:
-	install -Dm755 downgrade $(DESTDIR)/$(PREFIX)/bin/downgrade
-	install -Dm644 doc/downgrade.8 $(DESTDIR)/$(MANPREFIX)/man8/downgrade.8
-	install -Dm644 completion/bash $(DESTDIR)/$(PREFIX)/share/bash-completion/completions/downgrade
-	install -Dm644 completion/zsh $(DESTDIR)/$(PREFIX)/share/zsh/site-functions/_downgrade
+	install -Dm755 downgrade $(DESTDIR)$(PREFIX)/bin/downgrade
+	install -Dm644 doc/downgrade.8 $(DESTDIR)$(MANPREFIX)/man8/downgrade.8
+	install -Dm644 completion/bash $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade
+	install -Dm644 completion/zsh $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade
 
 uninstall:
-	$(RM) $(DESTDIR)/$(PREFIX)/bin/downgrade \
-	  $(DESTDIR)/$(MANPREFIX)/man8/downgrade.8 \
-	  $(DESTDIR)/$(PREFIX)/share/bash-completion/completions/downgrade \
-	  $(DESTDIR)/$(PREFIX)/share/zsh/site-functions/_downgrade
+	$(RM) $(DESTDIR)$(PREFIX)/bin/downgrade \
+	  $(DESTDIR)$(MANPREFIX)/man8/downgrade.8 \
+	  $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade
 
 .PHONY: setup test install uninstall
 

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ locale/downgrade.pot: downgrade
 		-o $@ $<
 	find ./locale/*po -exec msgmerge --update {} $@ \;
 
-downgrade.8: doc/downgrade.8.md
-	$(PANDOC) --standalone --to man doc/downgrade.8.md -o doc/downgrade.8
+doc/downgrade.8: doc/downgrade.8.md
+	$(PANDOC) --standalone --to man $< -o $@
 
-man: downgrade.8
+man: doc/downgrade.8
 
 test:
 	cram test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ LOCALEPREFIX ?= $(PREFIX)/share/locale
 MANPREFIX    ?= $(PREFIX)/share/man
 PANDOC       ?= $(shell which pandoc)
 
+.PHONY: setup
 setup:
 	command -v cram   || aurget cram
 	command -v vbump  || aurget vbump-git
@@ -19,11 +20,14 @@ locale/downgrade.pot: downgrade
 doc/downgrade.8: doc/downgrade.8.md
 	$(PANDOC) --standalone --to man $< -o $@
 
+.PHONY: man
 man: doc/downgrade.8
 
+.PHONY: test
 test:
 	cram test
 
+.PHONY: install
 install:
 	install -Dm755 downgrade $(DESTDIR)$(PREFIX)/bin/downgrade
 	install -Dm644 doc/downgrade.8 $(DESTDIR)$(MANPREFIX)/man8/downgrade.8
@@ -35,14 +39,13 @@ install:
 	  msgfmt "$$po_file" -o "$(DESTDIR)$(LOCALEPREFIX)/$$locale/LC_MESSAGES/downgrade.mo"; \
 	done
 
+.PHONY: uninstall
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/downgrade \
 	  $(DESTDIR)$(MANPREFIX)/man8/downgrade.8 \
 	  $(DESTDIR)$(PREFIX)/share/bash-completion/completions/downgrade \
 	  $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_downgrade \
 	  $(DESTDIR)$(LOCALEPREFIX)/*/LC_MESSAGES/downgrade.mo
-
-.PHONY: setup test install uninstall
 
 .PHONY: release.major
 release.major: VERSION=$(shell git tag | vbump major | sed 's/^v//')

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ locale/downgrade.pot: downgrade
 		--package-name=downgrade \
 		--copyright-holder=$(AUTHOR) \
 		-o $@ $<
+	find ./locale/*po -exec msgmerge --update {} $@ \;
 
 downgrade.8: doc/downgrade.8.md
 	$(PANDOC) --standalone --to man doc/downgrade.8.md -o doc/downgrade.8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Downgrade
 
-[![CircleCI](https://circleci.com/gh/pbrisbin/downgrade.svg?style=shield)](https://circleci.com/gh/pbrisbin/downgrade)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/pbrisbin/downgrade?label=release&logo=github&color=brightgreen)](https://github.com/pbrisbin/downgrade/releases)
+[![AUR version](https://img.shields.io/aur/version/downgrade?logo=Arch%20Linux&color=brightgreen)](https://aur.archlinux.org/packages/downgrade/)
+[![CircleCI](https://img.shields.io/circleci/build/github/pbrisbin/downgrade?logo=circleci)](https://circleci.com/gh/pbrisbin/downgrade)
 [![gitlocalized ](https://gitlocalize.com/repo/4232/whole_project/badge.svg)](https://gitlocalize.com/repo/4232/whole_project?utm_source=badge)
 
 Eases downgrading packages in Arch Linux.

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -11,7 +11,7 @@ pacman_option\&...]
 Downgrade Arch Linux packages.
 .SH OUTPUT
 .PP
-Just calling \f[C]downgrade\f[R] on a package will lead to the following
+Just calling \f[B]downgrade\f[R] on a package will lead to the following
 output:
 .PP
 \f[I]Example:\f[R]
@@ -141,7 +141,7 @@ The pacman log file is read from the pacman configuration file by
 default, or set to \f[I]/var/log/pacman.log\f[R] when not found.
 .SH EXIT CODES
 .PP
-Downgrade will stop further processing and exit non-zero if it
+\f[B]downgrade\f[R] will stop further processing and exit non-zero if it
 encounters any of the following scenarios for any of its arguments:
 .IP \[bu] 2
 No argument value(s) supplied where necessary

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -12,7 +12,7 @@ Downgrade Arch Linux packages.
 
 # OUTPUT
 
-Just calling `downgrade` on a package will lead to the following output:
+Just calling **downgrade** on a package will lead to the following output:
 
 *Example:*
 
@@ -104,7 +104,7 @@ The pacman log file is read from the pacman configuration file by default, or se
 
 # EXIT CODES
 
-Downgrade will stop further processing and exit non-zero if it encounters any of
+**downgrade** will stop further processing and exit non-zero if it encounters any of
 the following scenarios for any of its arguments:
 
 - No argument value(s) supplied where necessary

--- a/downgrade
+++ b/downgrade
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1091
 . gettext.sh
-export TEXTDOMAIN=downgrade
-export TEXTDOMAINDIR=/usr/share/locale
 
 usage() {
   cat <<EOF
@@ -384,5 +382,18 @@ cli() {
 
 if ((!LIB)); then
   set -e
+
+  locale="$(dirname "$0")"/../share/locale
+
+  if [[ -d "$locale" ]]; then
+    # Packaged installation
+    TEXTDOMAINDIR=$(cd "$locale" && pwd)
+  else
+    # Probably testing ./downgrade
+    TEXTDOMAINDIR=/usr/share/locale
+  fi
+
+  export TEXTDOMAIN=downgrade TEXTDOMAINDIR
+
   cli "$@"
 fi

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -16,120 +16,122 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
-msgstr "Použití: downgrade [argumenty...] <balíček> [balíček...] [-- <argumenty Pacmanu>]"
+msgstr ""
+"Použití: downgrade [argumenty...] <balíček> [balíček...] [-- <argumenty "
+"Pacmanu>]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Argumenty"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "příkaz"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "příkaz pacman, výchozí nastavení je"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "soubor"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "konfigurační soubor pacman, výchozí nastavení"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "architektura"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "cílová architektura, výchozí nastavení"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "umístění serveru ALA, výchozí nastavení je"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "používejte pouze server ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "používejte pouze balíčky v mezipaměti"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "nepoužívejte sudo, i když jsou k dispozici, použijte su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "zobrazit skript nápovědy"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Poznámka"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Možnosti za znaky -- budou považovány za možnosti pacmanu."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Pro více informací vizte downgrade(8)"
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Dostupné balíčky:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "vyberte balíček číslem: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "přidat $pkg mezi ignorované? [a/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "a"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "místní"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "vzdálený"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Neplatná volba"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Nelze downgradovat $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Chybí argument --pacman"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Chybí argument --pacman-conf"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Chybí argument --arch"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Chybí argument --ala-url"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"

--- a/locale/downgrade.pot
+++ b/locale/downgrade.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-21 15:29+0200\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,120 +16,120 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr ""
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr ""
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr ""
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr ""
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr ""
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr ""
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr ""
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr ""
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr ""
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr ""
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr ""
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr ""
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr ""
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr ""
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr ""
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr ""
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr ""
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr ""
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr ""
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr ""
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr ""
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr ""
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr ""
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr ""
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr ""
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr ""
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr ""
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-06 18:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 18:01-0400\n"
 "Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -17,120 +17,122 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "Uso: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Opciones"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "mando"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "comando pacman para usar, el valor predeterminado es"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "ruta de archivo"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "archivo de configuración de pacman, el valor predeterminado es"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "arquitectura"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "arquitectura de destino, por defecto a la salida de"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "ubicación del servidor ALA, el valor predeterminado es"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "solo use el servidor ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "solo use paquetes en caché"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "no use sudo incluso cuando esté disponible, use su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "mostrar guión de ayuda"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
-msgstr "Las opciones después de los caracteres -- se tratarán como opciones de pacman."
+msgstr ""
+"Las opciones después de los caracteres -- se tratarán como opciones de "
+"pacman."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Ver downgrade(8) para más detalles."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Paquetes disponibles:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "Selecciona un paquete por su número: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "Añadir $pkg a paquetes ignorados [s/n] "
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "s"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "local"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Elección inválida"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "No se puede degradar $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Falta el argumento --pacman"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Falta el argumento --pacman-conf"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Falta el argumento --arch"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Falta el argumento --arch-url"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -17,120 +17,124 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
-msgstr "Utilisation: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
+msgstr ""
+"Utilisation: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Les options"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "commander"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "commande pacman à utiliser, par défaut"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "chemin du fichier"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "fichier de configuration pacman, par défaut"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "architecture"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "architecture cible, sortie par défaut de"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "emplacement du serveur ALA, par défaut"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "utiliser uniquement le serveur ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "utiliser uniquement des packages mis en cache"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "n'utilisez pas sudo même lorsqu'il est disponible, utilisez su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "afficher le script d'aide"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Remarque"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
-msgstr "Les options après les caractères -- seront traitées comme des options pacman."
+msgstr ""
+"Les options après les caractères -- seront traitées comme des options pacman."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Voir downgrade(8) pour plus de détails."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Paquets disponibles :"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "Sélectionner le paquet numéro : "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
-msgstr "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour automatiquement ? [o/n] "
+msgstr ""
+"Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
+"automatiquement ? [o/n] "
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "o"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "local"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "distant"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Choix invalide"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Impossible de rétrograder $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Argument --pacman manquant"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Argument --pacman-conf manquant"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Argument --arch manquant"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Argument --ala-url manquant"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,131 +7,134 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
-"Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, <shankar.atreya@gmail.com>\n"
+"Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
+"<shankar.atreya@gmail.com>\n"
 "Language-Team: lt <margevicius.algimantas@gmail.com>\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.7\n"
-"Language: lt\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
-msgstr "Naudojimas: downgrade [option...] <paketas> [paketas...] [-- pacman_option...]"
+msgstr ""
+"Naudojimas: downgrade [option...] <paketas> [paketas...] [-- "
+"pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Galimybės"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "komanda"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "Pacman komanda, kurią reikia naudoti, numatytoji reikšmė yra"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "bylos kelias"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "Pacman konfigūracijos failas, pagal nutylėjimą"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "architektūra"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "taikinio architektūra, numatytoji reikšmė yra"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "ALA serverio vieta, numatytoji reikšmė"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "naudoti tik ALA serverį"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "naudokite tik talpykloje laikomus paketus"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "nenaudokite sudo, net jei įmanoma, naudokite su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "rodyti pagalbos scenarijų"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Pastaba"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Parinktys po simbolių -- bus traktuojamos kaip pacman parinktys."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Išsamiau galite paskaityti downgrade(8)."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Prieinami paketai:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "įveskite paketo numerį:"
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "pridėti $pkg į IgnorePkg? [t/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "t"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "vietinis"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "nutolęs"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Netinkamas pasirinkimas"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Neįmanoma paversti žemesnio lygio $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Trūksta argumento --pacman"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Trūksta argumento --pacman-conf"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Trūksta argumento --arch"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Trūksta argumento --ala-url"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,9 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
-"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail.com>\n"
+"Last-Translator: Hkon Vgsether <hauk142@gmail.com>, <shankar.atreya@gmail."
+"com>\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
@@ -17,120 +18,121 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "Bruk: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Alternativer"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "kommando"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "pacman-kommando for a bruke, er standard for"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "filsti"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "arkitektur"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "malarkitektur, standard for utdata fra"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "ikke bruk sudo selv om det er tilgjengelig, bruk su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
-msgstr "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
+msgstr ""
+"Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Se downgrade(8) for detaljer."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Tilgjengelige pakker:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "velg en pakke ved nummer: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "legg til $pkg i IgnorePkg? [j/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "j"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Kan ikke nedgradere $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Mangler --arch -argumentet"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"

--- a/locale/nn.po
+++ b/locale/nn.po
@@ -7,9 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
-"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail.com>\n"
+"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
+"com>\n"
 "Language-Team: Norwegian Nynorsk\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
@@ -17,120 +18,121 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "Bruk: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Alternativer"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "kommando"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "pacman-kommando for å bruke, er standard for"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "filsti"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "arkitektur"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "målarkitektur, standard for utdata fra"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "ikke bruk sudo selv om det er tilgjengelig, bruk su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
-msgstr "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
+msgstr ""
+"Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Sjå downgrade(8) for detaljar."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Tilgjengelege pakkar:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "vel ei pakke ved nummer: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "legg til $pkg i IgnorePkg? [j/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "j"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Kan ikke nedgradere $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Mangler --arch -argumentet"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,131 +7,133 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
+"Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
+"<shankar.atreya@gmail.com>\n"
 "Language-Team: \n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, <shankar.atreya@gmail.com>\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 "
+"|| n%100>14) ? 1 : 2);\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "Użycie: downgrade [opcje...] <pkg> [pkg...] [-- opcje_pacmana...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Opcje"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "komenda"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "do użycia komenda pacman, domyślnie"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "ścieżka pliku"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "plik konfiguracyjny pacmana, domyślnie"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "architektura"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "architektura docelowa, domyślnie wyjście"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "lokalizacja serwera ALA, domyślnie"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "używaj tylko serwera ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "używaj tylko pakietów buforowanych"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "nie używaj sudo, nawet jeśli jest dostępne, używaj su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "pokaż skrypt pomocy"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Uwaga"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Opcje po znakach -- będą traktowane jako opcje Pacman."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Zobacz downgrade(8) po szczegóły."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Dostępne pakiety:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "wybierz pakiet według numeru: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "dodać $pkg do IgnorePkg? [t/n] "
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "t"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "lokalnie"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "do pobrania"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Nie można obniżyć poziomu $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Brak argumentu --pacman"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Brak argumentu --pacman-conf"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Brak argumentu --arch"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Brak argumentu --ala-url"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,131 +7,132 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
-"Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar.atreya@gmail.com>\n"
+"Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
+"atreya@gmail.com>\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "Uso: downgrade [opções...] <pkg> [pkg...] [-- opções_do_pacman...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "Opções"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "comando"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "comando pacman a usar, o padrão é"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "caminho de arquivo"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "arquivo de configuração pacman, o padrão é"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "arquitetura"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "arquitetura de destino, o padrão é a saída de"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "localização do servidor ALA, o padrão é"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "use apenas o servidor ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "use apenas pacotes em cache"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "não use sudo, mesmo quando disponível, use su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "mostrar script de ajuda"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "As opções após os caracteres -- serão tratadas como opções do pacman."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "Veja downgrade(8) para mais detalhes."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Pacotes disponíveis:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "selecione um pacote por número:"
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "adicionar $pkg em IgnorePkg? [s/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "s"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "local"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Escolha inválida"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Não foi possível fazer o downgrade $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Argumento --pacman ausente"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Argumento --pacman-conf ausente"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Argumento --arch ausente"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Argumento --ala-url ausente"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-18 14:25-0300\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -15,122 +15,126 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: downgrade:7
+msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
+msgstr ""
+"использование: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 
 #: downgrade:9
-msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
-msgstr "использование: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
-
-#: downgrade:11
 msgid "Options"
 msgstr "Опции"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "команда"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "команда pacman для использования, по умолчанию"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "Путь файла"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "Файл конфигурации pacman, по умолчанию"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "архитектура"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "целевая архитектура, по умолчанию выводится"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "расположение сервера ALA, по умолчанию"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "использовать только сервер ALA"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "использовать только кэшированные пакеты"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "не используйте sudo, даже если доступно, используйте su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "показать скрипт помощи"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "Заметка"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
-msgstr "Параметры после символов -- будут рассматриваться как параметры pacman."
+msgstr ""
+"Параметры после символов -- будут рассматриваться как параметры pacman."
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "см. downgrade(8) для подробностей."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "Доступные пакеты:"
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "выберите пакет по номеру: "
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/н] "
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "д"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "локально"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "дистанционно"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "Неверный выбор"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "Невозможно понизить $term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "Отсутствует аргумент --pacman-conf"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "Отсутствует аргумент --arch"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "Отсутствует аргумент --ala-url"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-10-31 12:01-0400\n"
+"POT-Creation-Date: 2020-05-05 08:58-0400\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -17,120 +17,120 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.6.5\n"
 
-#: downgrade:9
+#: downgrade:7
 msgid "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]"
 msgstr "用法： downgrade [option...] <包> [包...] [-- pacman_option...]"
 
-#: downgrade:11
+#: downgrade:9
 msgid "Options"
 msgstr "选件"
 
-#: downgrade:12
+#: downgrade:10
 msgid "command"
 msgstr "命令"
 
-#: downgrade:13
+#: downgrade:11
 msgid "pacman command to use, defaults to"
 msgstr "使用的pacman命令，默认为"
 
-#: downgrade:14
+#: downgrade:12
 msgid "file-path"
 msgstr "文件路径"
 
-#: downgrade:15
+#: downgrade:13
 msgid "pacman configuration file, defaults to"
 msgstr "pacman配置文件，默认为"
 
-#: downgrade:16
+#: downgrade:14
 msgid "architecture"
 msgstr "建筑"
 
-#: downgrade:17
+#: downgrade:15
 msgid "target architecture, defaults to output of"
 msgstr "目标体系结构，默认为"
 
-#: downgrade:19
+#: downgrade:17
 msgid "location of ALA server, defaults to"
 msgstr "ALA服务器的位置，默认为"
 
-#: downgrade:20
+#: downgrade:18
 msgid "only use ALA server"
 msgstr "仅使用ALA服务器"
 
-#: downgrade:21
+#: downgrade:19
 msgid "only use cached packages"
 msgstr "只使用缓存的包"
 
-#: downgrade:22
+#: downgrade:20
 msgid "do not use sudo even when available, use su"
 msgstr "即使可用，也不要使用sudo，请使用su"
 
-#: downgrade:23
+#: downgrade:21
 msgid "show help script"
 msgstr "显示帮助脚本"
 
-#: downgrade:25
+#: downgrade:23
 msgid "Note"
 msgstr "注意"
 
-#: downgrade:26
+#: downgrade:24
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "--字符后的选项将被视为pacman选项。"
 
-#: downgrade:27
+#: downgrade:25
 msgid "See downgrade(8) for details."
 msgstr "详情请查看downgrade(8)."
 
-#: downgrade:60
+#: downgrade:58
 msgid "Available packages:"
 msgstr "可选的包："
 
-#: downgrade:70
+#: downgrade:68
 msgid "select a package by number: "
 msgstr "输入数字以选择包："
 
-#: downgrade:87
+#: downgrade:85
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "添加$pkg到IgnorePkg? [y/n]"
 
-#: downgrade:90
+#: downgrade:88
 msgid "y"
 msgstr "y"
 
-#: downgrade:165
+#: downgrade:163
 msgid "local"
 msgstr "本地"
 
-#: downgrade:167
+#: downgrade:165
 msgid "remote"
 msgstr "远端"
 
-#: downgrade:217
+#: downgrade:215
 msgid "Invalid choice"
 msgstr "选择无效"
 
-#: downgrade:244
+#: downgrade:242
 #, sh-format
 msgid "Unable to downgrade $term"
 msgstr "无法降级$term"
 
-#: downgrade:288
+#: downgrade:286
 msgid "Missing --pacman argument"
 msgstr "缺少--pacman参数"
 
-#: downgrade:301
+#: downgrade:299
 msgid "Missing --pacman-conf argument"
 msgstr "缺少--pacman-conf参数"
 
-#: downgrade:314
+#: downgrade:312
 msgid "Missing --arch argument"
 msgstr "缺少--arch参数"
 
-#: downgrade:327
+#: downgrade:325
 msgid "Missing --ala-url argument"
 msgstr "缺少--ala-url参数"
 
-#: downgrade:363
+#: downgrade:361
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"


### PR DESCRIPTION
**NOTE**: there are number of minor but distinct commits here, which I've pulled
from #114. Please consider reviewing this PR by paging through the Commits tab
one-by-one.

The important commits here are:

- 539160f Find TEXTDOMAINDIR relative to script

  Previously, downgrade hard-coded `/usr/share/locale`. This meant
  installation to an alternative `PREFIX` would still use `/usr` for the
  locale files, which is surprising.

  This change means that wherever downgrade is installed, it will find locales
  relative to itself. This is behavior neutral on Arch, since the PKGBUILD[1]
  uses an explicit `PREFIX` of `/usr`.

  A future commit will bring the locale files installation into the make install
  target, which will respect PREFIX. That will only function with the
  pre-requisite commit.

  [1]: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=downgrade

- 53b277b Handle locale files in make targets

  This was previously handled directly in the `PKGBUILD`, but there's no reason
  it can't be part of the general project targets. This ensures `PREFIX` is
  handled uniformly.