### PR TITLE
Add --pacman-cache, --pacman-log and --maxdepth to CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,21 @@ Install via the [AUR](https://aur.archlinux.org/packages/downgrade/).
 Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]
 
   Options:
-    --pacman <command>
+    --pacman        <command>
                     pacman command to use, defaults to "pacman"
-    --pacman-conf <file-path>
+    --pacman-conf   <path>
                     pacman configuration file, defaults to "/etc/pacman.conf"
-    --ala-url <url>
+    --pacman-cache  <path>
+                    pacman cache directory or directories,
+                    default value taken from pacman configuration file,
+                    or otherwise defaults to "/var/cache/pacman/pkg"
+    --pacman-log    <path>
+                    pacman log file,
+                    default value taken from pacman configuration file,
+                    or otherwise defaults to "/var/log/pacman.log"
+    --maxdepth      <integer>
+                    maximum depth to search for cached packages, defaults to 1
+    --ala-url       <url>
                     location of ALA server, defaults to "https://archive.archlinux.org"
     --ala-only      only use ALA server
     --cached-only   only use cached packages

--- a/completion/zsh
+++ b/completion/zsh
@@ -2,9 +2,12 @@
 
 _downgrade(){
   _arguments -S -C '*:packages:->pkg' \
-             '--pacman[Specify pacman command]' \
-             '--pacman-conf[Specify pacman configuration file]:config:_files' \
-             '--ala-url[Specify location of ALA server]' \
+             '--pacman[Specify pacman command]:pacman command' \
+             '--pacman-conf[Specify pacman configuration file]:pacman config file:_files' \
+             '--pacman-cache[Specify pacman cache directory or directories]:pacman cache directory:_path_files -/' \
+             '--pacman-log[Specify pacman log-file]:pacman log file:_files' \
+             '--maxdepth[Specify maximum depth for local cache find]:maximum search depth' \
+             '--ala-url[Specify location of ALA server]:ala url' \
              '--ala-only[Option enables only ALA server search]' \
              '--cached-only[Option enables only cached search]' \
              '--nosudo[Option enables only su even when sudo is present]' \

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -60,15 +60,25 @@ The columns have the following meaning:
 
 # OPTIONS
 
-## DOWNGRADE OPTIONS
-
 **\--pacman** *\<command\>*\
 
 > Pacman command, default is *pacman*.
 
-**\--pacman-conf** *\<file-path\>*\
+**\--pacman-conf** *\<path\>*\
   
 > Pacman configuration file, default is */etc/pacman.conf*.
+
+**\--pacman-cache** *\<path\>*\
+
+> Pacman cache directory or directories, default value is extracted from pacman configuration file, or otherwise defaults to */var/cache/pacman/pkg*. Multiple cache directories can be supplied as space-separated paths.
+
+**\--pacman-log** *\<path\>*\
+
+> Pacman log file, default value is extracted from pacman configuration file, or otherwise defaults to */var/log/pacman.log*.
+
+**\--maxdepth** *\<int\>*\
+
+> Maximum depth to search for cached packages, defaults to *1*.
 
 **\--ala-url** *\<url\>*\
 	
@@ -94,15 +104,11 @@ As per the usage syntax, any options supplied after the **\--** character sequen
 
 By default, **downgrade** will search both local caches and the ALA.
 
-The package cache directory is read from the pacman configuration file by default, or set to */var/cache/pacman/pkg/* when not found.
-
-The pacman log file is read from the pacman configuration file by default, or set to */var/log/pacman.log* when not found.
+If only one package with its corresponding location matches, the package will be installed without further prompt from the user.
 
 # VERSION FILTERING
 
 **downgrade** allows the use of the following version-filtering operators: **=**, **=~**, **<=**, **>=**, **<** and **>**. Note that **=~** represents a regex match operator.
-
-If only one package-path matches, the package will be installed without further prompt from the user.
 
 # EXIT CODES
 

--- a/downgrade
+++ b/downgrade
@@ -7,11 +7,21 @@ usage() {
 $(gettext "Usage: downgrade [option...] <pkg> [pkg...] [-- pacman_option...]")
 
   $(gettext "Options"):
-    --pacman <$(gettext "command")>
+    --pacman        <$(gettext "command")>
                     $(gettext "pacman command to use, defaults to") "pacman"
-    --pacman-conf <$(gettext "file-path")>
+    --pacman-conf   <$(gettext "path")>
                     $(gettext "pacman configuration file, defaults to") "/etc/pacman.conf"
-    --ala-url <url>
+    --pacman-cache  <$(gettext "path")>
+                    $(gettext "pacman cache directory or directories,")
+                    $(gettext "default value taken from pacman configuration file,")
+                    $(gettext "or otherwise defaults to") "/var/cache/pacman/pkg"
+    --pacman-log    <$(gettext "path")>
+                    $(gettext "pacman log file,")
+                    $(gettext "default value taken from pacman configuration file,")
+                    $(gettext "or otherwise defaults to") "/var/log/pacman.log"
+    --maxdepth      <$(gettext "integer")>
+                    $(gettext "maximum depth to search for cached packages, defaults to") 1
+    --ala-url       <url>
                     $(gettext "location of ALA server, defaults to") "https://archive.archlinux.org"
     --ala-only      $(gettext "only use ALA server")
     --cached-only   $(gettext "only use cached packages")
@@ -162,7 +172,7 @@ search_packages() {
     : "${PACMAN_CACHE:=/var/cache/pacman/pkg/}"
 
     # shellcheck disable=SC2086
-    find $PACMAN_CACHE -maxdepth 1 -regextype posix-extended -regex ".*/$pkgfile_re"
+    find $PACMAN_CACHE -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
   fi
 }
 
@@ -302,6 +312,7 @@ main() {
 : "${DOWNGRADE_FROM_ALA:=1}"
 : "${DOWNGRADE_FROM_CACHE:=1}"
 : "${DOWNGRADE_NOSUDO:=0}"
+: "${DOWNGRADE_MAXDEPTH:=1}"
 
 declare -a terms
 declare -a to_ignore
@@ -346,6 +357,45 @@ parse_options() {
         else
           {
             gettext "Missing --ala-url argument"
+            echo
+            usage
+          } >&2
+          exit 1
+        fi
+        ;;
+      --pacman-cache)
+        if [[ -n "$2" ]]; then
+          shift
+          PACMAN_CACHE="$1"
+        else
+          {
+            gettext "Missing --pacman-cache argument"
+            echo
+            usage
+          } >&2
+          exit 1
+        fi
+        ;;
+      --pacman-log)
+        if [[ -n "$2" ]]; then
+          shift
+          PACMAN_LOG="$1"
+        else
+          {
+            gettext "Missing --pacman-log argument"
+            echo
+            usage
+          } >&2
+          exit 1
+        fi
+        ;;
+      --maxdepth)
+        if [[ -n "$2" ]]; then
+          shift
+          DOWNGRADE_MAXDEPTH="$1"
+        else
+          {
+            gettext "Missing --maxdepth argument"
             echo
             usage
           } >&2

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:02+0200\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -34,8 +34,8 @@ msgstr "příkaz"
 msgid "pacman command to use, defaults to"
 msgstr "příkaz pacman, výchozí nastavení je"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "soubor"
 
 #: downgrade:13
@@ -43,84 +43,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "konfigurační soubor pacman, výchozí nastavení"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "adresář nebo adresáře mezipaměti pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "výchozí hodnota převzatá z konfiguračního souboru pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "nebo jinak výchozí"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "soubor protokolu pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "celé číslo"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+"maximální hloubka pro vyhledávání balíčků v mezipaměti, výchozí hodnota"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "umístění serveru ALA, výchozí nastavení je"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "používejte pouze server ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "používejte pouze balíčky v mezipaměti"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "nepoužívejte sudo, i když jsou k dispozici, použijte su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "zobrazit skript nápovědy"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Poznámka"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Možnosti za znaky -- budou považovány za možnosti pacmanu."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Pro více informací vizte downgrade(8)"
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Dostupné balíčky:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "vyberte balíček číslem: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "přidat $pkg mezi ignorované? [a/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "a"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "místní"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "vzdálený"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Neplatná volba"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nelze downgradovat $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Chybí argument --pacman"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Chybí argument --pacman-conf"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Chybí argument --ala-url"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Chybí argument --pacman-cache"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Chybí argument --pacman-log"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Chybí argument --maxdepth"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 
@@ -129,6 +166,3 @@ msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "cílová architektura, výchozí nastavení"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Chybí argument --arch"

--- a/locale/downgrade.pot
+++ b/locale/downgrade.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,8 +32,8 @@ msgstr ""
 msgid "pacman command to use, defaults to"
 msgstr ""
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr ""
 
 #: downgrade:13
@@ -41,83 +41,119 @@ msgid "pacman configuration file, defaults to"
 msgstr ""
 
 #: downgrade:15
-msgid "location of ALA server, defaults to"
+msgid "pacman cache directory or directories,"
 msgstr ""
 
-#: downgrade:16
-msgid "only use ALA server"
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
 msgstr ""
 
-#: downgrade:17
-msgid "only use cached packages"
-msgstr ""
-
-#: downgrade:18
-msgid "do not use sudo even when available, use su"
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
 msgstr ""
 
 #: downgrade:19
-msgid "show help script"
-msgstr ""
-
-#: downgrade:21
-msgid "Note"
+msgid "pacman log file,"
 msgstr ""
 
 #: downgrade:22
-msgid "Options after the -- characters will be treated as pacman options."
+msgid "integer"
 msgstr ""
 
 #: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+
+#: downgrade:25
+msgid "location of ALA server, defaults to"
+msgstr ""
+
+#: downgrade:26
+msgid "only use ALA server"
+msgstr ""
+
+#: downgrade:27
+msgid "only use cached packages"
+msgstr ""
+
+#: downgrade:28
+msgid "do not use sudo even when available, use su"
+msgstr ""
+
+#: downgrade:29
+msgid "show help script"
+msgstr ""
+
+#: downgrade:31
+msgid "Note"
+msgstr ""
+
+#: downgrade:32
+msgid "Options after the -- characters will be treated as pacman options."
+msgstr ""
+
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr ""
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr ""
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr ""
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr ""
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr ""
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr ""
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr ""
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr ""
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr ""
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr ""
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr ""
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr ""
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr ""
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr ""
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr ""
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the PACKAGE package.
 # <miachm3@gmail.com>, 2020.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 18:01-0400\n"
 "Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -33,8 +32,8 @@ msgstr "mando"
 msgid "pacman command to use, defaults to"
 msgstr "comando pacman para usar, el valor predeterminado es"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "ruta de archivo"
 
 #: downgrade:13
@@ -42,86 +41,123 @@ msgid "pacman configuration file, defaults to"
 msgstr "archivo de configuración de pacman, el valor predeterminado es"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "directorio o directorios de caché pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valor predeterminado tomado del archivo de configuración de pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "o por defecto es"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "archivo de registro de pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "entero"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+"profundidad máxima para buscar paquetes en caché, el valor predeterminado es"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "ubicación del servidor ALA, el valor predeterminado es"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "solo use el servidor ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "solo use paquetes en caché"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "no use sudo incluso cuando esté disponible, use su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "mostrar guión de ayuda"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Las opciones después de los caracteres -- se tratarán como opciones de "
 "pacman."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Ver downgrade(8) para más detalles."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Paquetes disponibles:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "Selecciona un paquete por su número: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "Añadir $pkg a paquetes ignorados [s/n] "
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "s"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "local"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Elección inválida"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "No se puede degradar $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Falta el argumento --pacman"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Falta el argumento --pacman-conf"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
-msgstr "Falta el argumento --arch-url"
+msgstr "Falta el argumento --ala-url"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Falta el argumento --pacman-cache"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Falta el argumento --pacman-log"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Falta el argumento --maxdepth"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"
 
@@ -130,6 +166,3 @@ msgstr "No se proporcionan paquetes para degradar"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "arquitectura de destino, por defecto a la salida de"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Falta el argumento --arch"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -34,8 +34,8 @@ msgstr "commander"
 msgid "pacman command to use, defaults to"
 msgstr "commande pacman à utiliser, par défaut"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "chemin du fichier"
 
 #: downgrade:13
@@ -43,87 +43,124 @@ msgid "pacman configuration file, defaults to"
 msgstr "fichier de configuration pacman, par défaut"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "répertoire ou répertoires de cache pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valeur par défaut extraite du fichier de configuration de pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "ou par défaut"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "fichier journal pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "entier"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+"profondeur maximale pour rechercher les packages mis en cache, par défaut"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "emplacement du serveur ALA, par défaut"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "utiliser uniquement le serveur ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "utiliser uniquement des packages mis en cache"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "n'utilisez pas sudo même lorsqu'il est disponible, utilisez su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "afficher le script d'aide"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Remarque"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Les options après les caractères -- seront traitées comme des options pacman."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Voir downgrade(8) pour plus de détails."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Paquets disponibles :"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "Sélectionner le paquet numéro : "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr ""
 "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
 "automatiquement ? [o/n] "
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "o"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "local"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "distant"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Choix invalide"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Impossible de rétrograder $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Argument --pacman manquant"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Argument --pacman-conf manquant"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Argument --ala-url manquant"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Argument --pacman-cache manquant"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Argument --pacman-log manquant"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Argument --maxdepth manquant"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"
 
@@ -132,6 +169,3 @@ msgstr "Aucun package fourni pour la rétrogradation"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "architecture cible, sortie par défaut de"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Argument --arch manquant"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
 "Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -37,8 +37,8 @@ msgstr "komanda"
 msgid "pacman command to use, defaults to"
 msgstr "Pacman komanda, kurią reikia naudoti, numatytoji reikšmė yra"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "bylos kelias"
 
 #: downgrade:13
@@ -46,84 +46,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "Pacman konfigūracijos failas, pagal nutylėjimą"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "Pacman talpyklos katalogas arba katalogai,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "numatytoji vertė, paimta iš pacman konfigūracijos failo,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "arba kitaip pagal nutylėjimą yra"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "Pacman žurnalo failas"
+
+#: downgrade:22
+msgid "integer"
+msgstr "sveikasis skaičius"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+"maksimalus gylis ieškant talpykloje esančių paketų, numatytasis reikšmė yra"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "ALA serverio vieta, numatytoji reikšmė"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "naudoti tik ALA serverį"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "naudokite tik talpykloje laikomus paketus"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "nenaudokite sudo, net jei įmanoma, naudokite su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "rodyti pagalbos scenarijų"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Pastaba"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Parinktys po simbolių -- bus traktuojamos kaip pacman parinktys."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Išsamiau galite paskaityti downgrade(8)."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Prieinami paketai:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "įveskite paketo numerį:"
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "pridėti $pkg į IgnorePkg? [t/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "t"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "vietinis"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "nutolęs"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Netinkamas pasirinkimas"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Neįmanoma paversti žemesnio lygio $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Trūksta argumento --pacman"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Trūksta argumento --pacman-conf"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Trūksta argumento --ala-url"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Trūksta argumento --pacman-cache"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Trūksta argumento --pacman-log"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Trūksta argumento --maxdepth"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 
@@ -132,6 +169,3 @@ msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "taikinio architektūra, numatytoji reikšmė yra"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Trūksta argumento --arch"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
-"Last-Translator: Hkon Vgsether <hauk142@gmail.com>, <shankar.atreya@gmail."
+"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=ASCII\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -32,10 +32,10 @@ msgstr "kommando"
 
 #: downgrade:11
 msgid "pacman command to use, defaults to"
-msgstr "pacman-kommando for a bruke, er standard for"
+msgstr "pacman-kommando for å bruke, er standard for"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "filsti"
 
 #: downgrade:13
@@ -43,85 +43,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "pacman cache-katalog eller kataloger,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "eller på annen måte standard til"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "plassering av ALA-server, er standard til"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "pacman-loggfil"
+
+#: downgrade:22
+msgid "integer"
+msgstr "heltall"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr "maksimal dybde for å søke etter hurtigbufrede pakker, som standard"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "ikke bruk sudo selv om det er tilgjengelig, bruk su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Se downgrade(8) for detaljer."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Tilgjengelige pakker:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "velg en pakke ved nummer: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "legg til $pkg i IgnorePkg? [j/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "j"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Mangler --pacman-cache -argumentet"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Mangler --pacman-log -argumentet"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Mangler --maxdepth -argumentet"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
@@ -130,6 +166,3 @@ msgstr "Ingen pakker gitt for nedgradering"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "malarkitektur, standard for utdata fra"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Mangler --arch -argumentet"

--- a/locale/nn.po
+++ b/locale/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -34,8 +34,8 @@ msgstr "kommando"
 msgid "pacman command to use, defaults to"
 msgstr "pacman-kommando for å bruke, er standard for"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "filsti"
 
 #: downgrade:13
@@ -43,85 +43,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "pacman cache-katalog eller kataloger,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "eller på annen måte standard til"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "plassering av ALA-server, er standard til"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "pacman-loggfil"
+
+#: downgrade:22
+msgid "integer"
+msgstr "heltall"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr "maksimal dybde for å søke etter hurtigbufrede pakker, som standard"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "ikke bruk sudo selv om det er tilgjengelig, bruk su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Sjå downgrade(8) for detaljar."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Tilgjengelege pakkar:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "vel ei pakke ved nummer: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "legg til $pkg i IgnorePkg? [j/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "j"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Mangler --pacman-cache -argumentet"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Mangler --pacman-log -argumentet"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Mangler --maxdepth -argumentet"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
@@ -130,6 +166,3 @@ msgstr "Ingen pakker gitt for nedgradering"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "målarkitektur, standard for utdata fra"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Mangler --arch -argumentet"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
 "Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -36,8 +36,8 @@ msgstr "komenda"
 msgid "pacman command to use, defaults to"
 msgstr "do użycia komenda pacman, domyślnie"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "ścieżka pliku"
 
 #: downgrade:13
@@ -45,84 +45,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "plik konfiguracyjny pacmana, domyślnie"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "katalog lub katalogi pamięci podręcznej pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "wartość domyślna pobrana z pliku konfiguracyjnego pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "lub w inny sposób domyślnie"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "plik dziennika pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "liczba całkowita"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr ""
+"maksymalna głębokość do wyszukiwania pakietów w pamięci podręcznej, domyślnie"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "lokalizacja serwera ALA, domyślnie"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "używaj tylko serwera ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "używaj tylko pakietów buforowanych"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "nie używaj sudo, nawet jeśli jest dostępne, używaj su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "pokaż skrypt pomocy"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Uwaga"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Opcje po znakach -- będą traktowane jako opcje Pacman."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Zobacz downgrade(8) po szczegóły."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Dostępne pakiety:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "wybierz pakiet według numeru: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "dodać $pkg do IgnorePkg? [t/n] "
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "t"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "lokalnie"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "do pobrania"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nie można obniżyć poziomu $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Brak argumentu --pacman"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Brak argumentu --pacman-conf"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Brak argumentu --ala-url"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Brak argumentu --pacman-cache"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Brak argumentu --pacman-log"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Brak argumentu --maxdepth"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"
 
@@ -131,6 +168,3 @@ msgstr "Brak pakietów do obniżenia"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "architektura docelowa, domyślnie wyjście"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Brak argumentu --arch"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
 "Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
 "atreya@gmail.com>\n"
@@ -35,8 +35,8 @@ msgstr "comando"
 msgid "pacman command to use, defaults to"
 msgstr "comando pacman a usar, o padrão é"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "caminho de arquivo"
 
 #: downgrade:13
@@ -44,84 +44,120 @@ msgid "pacman configuration file, defaults to"
 msgstr "arquivo de configuração pacman, o padrão é"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "diretório ou diretórios de cache pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valor padrão obtido do arquivo de configuração pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "ou o padrão é"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "arquivo de log pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "inteiro"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr "profundidade máxima para procurar pacotes em cache, o padrão é"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "localização do servidor ALA, o padrão é"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "use apenas o servidor ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "use apenas pacotes em cache"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "não use sudo, mesmo quando disponível, use su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "mostrar script de ajuda"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "As opções após os caracteres -- serão tratadas como opções do pacman."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Veja downgrade(8) para mais detalhes."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Pacotes disponíveis:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "selecione um pacote por número:"
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "adicionar $pkg em IgnorePkg? [s/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "s"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "local"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Escolha inválida"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Não foi possível fazer o downgrade $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Argumento --pacman ausente"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Argumento --pacman-conf ausente"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Argumento --ala-url ausente"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Argumento --pacman-cache ausente"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Argumento --pacman-log ausente"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Argumento --maxdepth ausente"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"
 
@@ -130,6 +166,3 @@ msgstr "Nenhum pacote fornecido para desatualização"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "arquitetura de destino, o padrão é a saída de"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Argumento --arch ausente"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -36,8 +36,8 @@ msgstr "команда"
 msgid "pacman command to use, defaults to"
 msgstr "команда pacman для использования, по умолчанию"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "Путь файла"
 
 #: downgrade:13
@@ -45,85 +45,121 @@ msgid "pacman configuration file, defaults to"
 msgstr "Файл конфигурации pacman, по умолчанию"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "каталог или каталоги кэша pacman,"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "значение по умолчанию берется из файла конфигурации pacman,"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "или по умолчанию"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "файл журнала pacman"
+
+#: downgrade:22
+msgid "integer"
+msgstr "целое число"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr "максимальная глубина для поиска в кэшированных пакетах, по умолчанию"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "расположение сервера ALA, по умолчанию"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "использовать только сервер ALA"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "использовать только кэшированные пакеты"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "не используйте sudo, даже если доступно, используйте su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "показать скрипт помощи"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "Заметка"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Параметры после символов -- будут рассматриваться как параметры pacman."
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "см. downgrade(8) для подробностей."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "Доступные пакеты:"
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "выберите пакет по номеру: "
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/н] "
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "д"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "локально"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "дистанционно"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "Неверный выбор"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Невозможно понизить $name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "Отсутствует аргумент --pacman-conf"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "Отсутствует аргумент --ala-url"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "Отсутствует аргумент --pacman-cache"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "Отсутствует аргумент --pacman-log"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "Отсутствует аргумент --maxdepth"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"
 
@@ -132,6 +168,3 @@ msgstr "Нет пакетов для понижения"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "целевая архитектура, по умолчанию выводится"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "Отсутствует аргумент --arch"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 19:36+0200\n"
+"POT-Creation-Date: 2020-05-11 20:00+0200\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -33,8 +33,8 @@ msgstr "命令"
 msgid "pacman command to use, defaults to"
 msgstr "使用的pacman命令，默认为"
 
-#: downgrade:12
-msgid "file-path"
+#: downgrade:12 downgrade:14 downgrade:18
+msgid "path"
 msgstr "文件路径"
 
 #: downgrade:13
@@ -42,84 +42,120 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman配置文件，默认为"
 
 #: downgrade:15
+msgid "pacman cache directory or directories,"
+msgstr "pacman缓存目录，"
+
+#: downgrade:16 downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "取自pacman配置文件的默认值，"
+
+#: downgrade:17 downgrade:21
+msgid "or otherwise defaults to"
+msgstr "否则默认为"
+
+#: downgrade:19
+msgid "pacman log file,"
+msgstr "pacman日志文件"
+
+#: downgrade:22
+msgid "integer"
+msgstr "整数"
+
+#: downgrade:23
+msgid "maximum depth to search for cached packages, defaults to"
+msgstr "搜索缓存包的最大深度，默认为"
+
+#: downgrade:25
 msgid "location of ALA server, defaults to"
 msgstr "ALA服务器的位置，默认为"
 
-#: downgrade:16
+#: downgrade:26
 msgid "only use ALA server"
 msgstr "仅使用ALA服务器"
 
-#: downgrade:17
+#: downgrade:27
 msgid "only use cached packages"
 msgstr "只使用缓存的包"
 
-#: downgrade:18
+#: downgrade:28
 msgid "do not use sudo even when available, use su"
 msgstr "即使可用，也不要使用sudo，请使用su"
 
-#: downgrade:19
+#: downgrade:29
 msgid "show help script"
 msgstr "显示帮助脚本"
 
-#: downgrade:21
+#: downgrade:31
 msgid "Note"
 msgstr "注意"
 
-#: downgrade:22
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "--字符后的选项将被视为pacman选项。"
 
-#: downgrade:23
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "详情请查看downgrade(8)."
 
-#: downgrade:56
+#: downgrade:66
 msgid "Available packages:"
 msgstr "可选的包："
 
-#: downgrade:66
+#: downgrade:76
 msgid "select a package by number: "
 msgstr "输入数字以选择包："
 
-#: downgrade:83
+#: downgrade:93
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/n] "
 msgstr "添加$pkg到IgnorePkg? [y/n]"
 
-#: downgrade:86
+#: downgrade:96
 msgid "y"
 msgstr "y"
 
-#: downgrade:196
+#: downgrade:206
 msgid "local"
 msgstr "本地"
 
-#: downgrade:198
+#: downgrade:208
 msgid "remote"
 msgstr "远端"
 
-#: downgrade:253
+#: downgrade:263
 msgid "Invalid choice"
 msgstr "选择无效"
 
-#: downgrade:267
+#: downgrade:277
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "无法降级$name"
 
-#: downgrade:322
+#: downgrade:333
 msgid "Missing --pacman argument"
 msgstr "缺少--pacman参数"
 
-#: downgrade:335
+#: downgrade:346
 msgid "Missing --pacman-conf argument"
 msgstr "缺少--pacman-conf参数"
 
-#: downgrade:348
+#: downgrade:359
 msgid "Missing --ala-url argument"
 msgstr "缺少--ala-url参数"
 
-#: downgrade:384
+#: downgrade:372
+msgid "Missing --pacman-cache argument"
+msgstr "缺少--pacman-cache参数"
+
+#: downgrade:385
+msgid "Missing --pacman-log argument"
+msgstr "缺少--pacman-log参数"
+
+#: downgrade:398
+msgid "Missing --maxdepth argument"
+msgstr "缺少--maxdepth参数"
+
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"
 
@@ -128,6 +164,3 @@ msgstr "没有提供降级包"
 
 #~ msgid "target architecture, defaults to output of"
 #~ msgstr "目标体系结构，默认为"
-
-#~ msgid "Missing --arch argument"
-#~ msgstr "缺少--arch参数"

--- a/test/options_sanity/options_sanity.t
+++ b/test/options_sanity/options_sanity.t
@@ -2,40 +2,52 @@
 
 Checking that CLI options match up with environmental variables, packages and pacman options
 
-  $ parse_options --pacman foo --pacman-conf bar --ala-url bat --ala-only pkg1 pkg2 -- -Syu; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only pkg1 pkg2 -- -Syu; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
   foo
   bar
   bat
+  /home/
+  /home/test.log
+  10
   1
   0
   0
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --ala-url bat --cached-only -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
   foo
   bar
   bat
+  /home/
+  /home/test.log
+  10
   0
   1
   0
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --ala-url bat --ala-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
   foo
   bar
   bat
+  /home/
+  /home/test.log
+  10
   1
   0
   1
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --ala-url bat --cached-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
   foo
   bar
   bat
+  /home/
+  /home/test.log
+  10
   0
   1
   1


### PR DESCRIPTION
This PR addresses #120 by adding `--pacman-cache`, `--pacman-log` and `--maxdepth` as CLI options. Commits have been chunked to represent discrete components of this PR.

Regarding whether to include `--maxdepth` at all, I think it is a good idea to include this parameter to ensure that `find` does not get stuck searching some deep user-defined cache directory. The user can add an arbitrarily large value for this if they want to search some basic cache directory for (eg.) AUR packages.