### PR TITLE
Error handling for unrecognized command-line options

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -422,6 +422,17 @@ parse_options() {
         pacman_args=("$@")
         break
         ;;
+      -*)
+        local current_option
+        # shellcheck disable=SC2034
+        current_option="$1"
+        {
+          eval_gettext "Unrecognized option \$current_option"
+          echo
+          usage
+        } >&2
+        exit 1
+        ;;
       *)
         terms+=("$1")
         ;;

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:02+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -157,7 +157,12 @@ msgstr "Chybí argument --pacman-log"
 msgid "Missing --maxdepth argument"
 msgstr "Chybí argument --maxdepth"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Nerozpoznaná možnost $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 

--- a/locale/downgrade.pot
+++ b/locale/downgrade.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 14:46-0400\n"
+"POT-Creation-Date: 2020-05-16 17:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,6 +154,11 @@ msgstr ""
 msgid "Missing --maxdepth argument"
 msgstr ""
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr ""
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 18:01-0400\n"
 "Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -157,7 +157,12 @@ msgstr "Falta el argumento --pacman-log"
 msgid "Missing --maxdepth argument"
 msgstr "Falta el argumento --maxdepth"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Opción no reconocida $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -160,7 +160,12 @@ msgstr "Argument --pacman-log manquant"
 msgid "Missing --maxdepth argument"
 msgstr "Argument --maxdepth manquant"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Option non reconnue $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"
 

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
 "Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -160,7 +160,12 @@ msgstr "Trūksta argumento --pacman-log"
 msgid "Missing --maxdepth argument"
 msgstr "Trūksta argumento --maxdepth"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Neatpažinta parinktis $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -157,7 +157,12 @@ msgstr "Mangler --pacman-log -argumentet"
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Ukjent alternativ $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 

--- a/locale/nn.po
+++ b/locale/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -157,7 +157,12 @@ msgstr "Mangler --pacman-log -argumentet"
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Ukjent alternativ $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
 "Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -159,7 +159,12 @@ msgstr "Brak argumentu --pacman-log"
 msgid "Missing --maxdepth argument"
 msgstr "Brak argumentu --maxdepth"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Nierozpoznana opcja $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
 "Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
 "atreya@gmail.com>\n"
@@ -157,7 +157,12 @@ msgstr "Argumento --pacman-log ausente"
 msgid "Missing --maxdepth argument"
 msgstr "Argumento --maxdepth ausente"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Opção não reconhecida $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -159,7 +159,12 @@ msgstr "Отсутствует аргумент --pacman-log"
 msgid "Missing --maxdepth argument"
 msgstr "Отсутствует аргумент --maxdepth"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "Нераспознанная опция $current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-11 20:00+0200\n"
+"POT-Creation-Date: 2020-05-16 17:19+0200\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -155,7 +155,12 @@ msgstr "缺少--pacman-log参数"
 msgid "Missing --maxdepth argument"
 msgstr "缺少--maxdepth参数"
 
-#: downgrade:434
+#: downgrade:429
+#, sh-format
+msgid "Unrecognized option $current_option"
+msgstr "无法识别的选项$current_option"
+
+#: downgrade:444
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"
 

--- a/test/options_sanity/unrecognized_option.t
+++ b/test/options_sanity/unrecognized_option.t
@@ -1,0 +1,11 @@
+$ source "$TESTDIR/../helper.sh"
+
+Checking that unrecognized options are caught and parsing exits non-zero
+
+$ parse_options --nonsense foo 2>/dev/null; exit_code=$?
+> printf "exit code: %s\n" "$exit_code"
+exit code: 1
+
+$ parse_options -nonsense bar 2>/dev/null; exit_code=$?
+> printf "exit code: %s\n" "$exit_code"
+exit code: 1


### PR DESCRIPTION
With the increasing number of command-line options (given proposals in #118), I thought it would be a good idea to introduce another error handling procedure during parsing options in case an option is not recognized (perhaps was spelt wrongly).

The current behaviour would just add an unrecognized option as a package to downgrade; and maybe this could be considered annoying.

This PR catches any option starting with a `-` that is not captured as `--` or by any of the existing command-line options. I checked the arch package repositories and could not find any package starting with a `-`, so I think this is a safe assumption to catch an unrecognized option.

I updated the tests to check for this. I also updated the locales to include a new key.