### PR TITLE
Adding -L flag to find to search explicitly provided symlinks

### DIFF
--- a/downgrade
+++ b/downgrade
@@ -172,7 +172,7 @@ search_packages() {
     : "${PACMAN_CACHE:=/var/cache/pacman/pkg/}"
 
     # shellcheck disable=SC2086
-    find $PACMAN_CACHE -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
+    find -L $PACMAN_CACHE -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
   fi
 }
 


### PR DESCRIPTION
This PR addresses #119 where `downgrade` does not follow symlink(s) to another cache directory. This is because of the default behaviour of `find`. To address this, we can add the `-L` flag to `find`, such that it will traverse all symlinks to find relevant cached tarballs. Despite some reservations, this is still made secure because of the `--maxdepth` option which would prevent problematic recursions.

PS: I left out the locale update for when we release. I think we can release this and the previous commits for unrecognized options as a minor version bump.