### PR TITLE
Release v8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [Ongoing](https://github.com/pbrisbin/downgrade/compare/v8.1.0...master)
+## [Ongoing](https://github.com/pbrisbin/downgrade/compare/v8.1.1...master)
 
 None
+
+## [v8.1.1](https://github.com/pbrisbin/downgrade/compare/v8.1.0...v8.1.1)
+
+- [NEW] Addition of autocompletion script for `fish` (@Jakeler)
 
 ## [v8.1.0](https://github.com/pbrisbin/downgrade/compare/v8.0.0...v8.1.0)
 


### PR DESCRIPTION
PR for patch version bump to `v8.1.1`, address #131. After the merge, will create the tag via GitHub UI (should be possible) and then update the AUR.