### PR TITLE
Pacman cache accumulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ default behavior:
 $ downgrade foo bar
 ```
 
+Downgrade packages, specifying multiple cache directories:
+
+```
+$ downgrade --pacman-cache /path/to/cache --pacman-cache /path/to/other/cache foo bar
+```
+
 Downgrade a package with any of the following version-filtering operators `=`,
 `=~`, `<=`, `>=`, `<` and `>`:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Options:
   --pacman-conf   <path>
                   pacman configuration file, defaults to "/etc/pacman.conf"
   --pacman-cache  <path>
-                  pacman cache directory or directories,
-                  default value taken from pacman configuration file,
+                  pacman cache directory,
+                  default value(s) taken from pacman configuration file,
                   or otherwise defaults to "/var/cache/pacman/pkg"
   --pacman-log    <path>
                   pacman log file,

--- a/completion/zsh
+++ b/completion/zsh
@@ -4,7 +4,7 @@ _downgrade(){
   _arguments -S -C '*:packages:->pkg' \
              '--pacman[Specify pacman command]:pacman command' \
              '--pacman-conf[Specify pacman configuration file]:pacman config file:_files' \
-             '--pacman-cache[Specify pacman cache directory or directories]:pacman cache directory:_path_files -/' \
+             '*--pacman-cache[Specify pacman cache directory or directories]:pacman cache directory:_path_files -/' \
              '--pacman-log[Specify pacman log-file]:pacman log file:_files' \
              '--maxdepth[Specify maximum depth for local cache find]:maximum search depth' \
              '--ala-url[Specify location of ALA server]:ala url' \

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -84,10 +84,10 @@ Pacman configuration file, default is \f[I]/etc/pacman.conf\f[R].
 .PD
 .RS
 .PP
-Pacman cache directory or directories, default value is extracted from
-pacman configuration file, or otherwise defaults to
-\f[I]/var/cache/pacman/pkg\f[R].
-Multiple cache directories can be supplied as space-separated paths.
+Pacman cache directory, default value(s) taken from pacman configuration
+file, or otherwise defaults to \f[I]/var/cache/pacman/pkg\f[R].
+This option can be specified multiple times to indicate multiple cache
+directories.
 .RE
 .PP
 \f[B]--pacman-log\f[R] \f[I]<path>\f[R]

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -65,12 +65,12 @@ The columns have the following meaning:
 > Pacman command, default is *pacman*.
 
 **\--pacman-conf** *\<path\>*\
-  
+
 > Pacman configuration file, default is */etc/pacman.conf*.
 
 **\--pacman-cache** *\<path\>*\
 
-> Pacman cache directory or directories, default value is extracted from pacman configuration file, or otherwise defaults to */var/cache/pacman/pkg*. Multiple cache directories can be supplied as space-separated paths.
+> Pacman cache directory, default value(s) taken from pacman configuration file, or otherwise defaults to */var/cache/pacman/pkg*. This option can be specified multiple times to indicate multiple cache directories.
 
 **\--pacman-log** *\<path\>*\
 

--- a/downgrade
+++ b/downgrade
@@ -12,8 +12,8 @@ $(gettext "Options"):
   --pacman-conf   <$(gettext "path")>
                   $(gettext "pacman configuration file, defaults to") "/etc/pacman.conf"
   --pacman-cache  <$(gettext "path")>
-                  $(gettext "pacman cache directory or directories,")
-                  $(gettext "default value taken from pacman configuration file,")
+                  $(gettext "pacman cache directory,")
+                  $(gettext "default value(s) taken from pacman configuration file,")
                   $(gettext "or otherwise defaults to") "/var/cache/pacman/pkg"
   --pacman-log    <$(gettext "path")>
                   $(gettext "pacman log file,")

--- a/downgrade
+++ b/downgrade
@@ -168,11 +168,16 @@ search_packages() {
 
   if ((DOWNGRADE_FROM_CACHE)); then
     # Delay this defaulting so #read_pacman_conf behavior is tested
-    : "${PACMAN_CACHE:=$(read_pacman_conf CacheDir)}"
-    : "${PACMAN_CACHE:=/var/cache/pacman/pkg/}"
+    if ((!${#PACMAN_CACHE[@]})); then
+      mapfile -t PACMAN_CACHE < <(read_pacman_conf CacheDir)
+    fi
+
+    if ((!${#PACMAN_CACHE[@]})); then
+      PACMAN_CACHE=(/var/cache/pacman/pkg/)
+    fi
 
     # shellcheck disable=SC2086
-    find -L $PACMAN_CACHE -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
+    find -L "${PACMAN_CACHE[@]}" -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
   fi
 }
 
@@ -366,7 +371,7 @@ parse_options() {
       --pacman-cache)
         if [[ -n "$2" ]]; then
           shift
-          PACMAN_CACHE="$1"
+          PACMAN_CACHE+=("$1")
         else
           {
             gettext "Missing --pacman-cache argument"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -43,11 +43,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "konfigurační soubor pacman, výchozí nastavení"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "adresář nebo adresáře mezipaměti pacman,"
+msgid "pacman cache directory,"
+msgstr "adresář mezipaměti pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "výchozí hodnota převzatá z konfiguračního souboru pacman,"
 
 #: downgrade:17 downgrade:21
@@ -57,6 +57,10 @@ msgstr "nebo jinak výchozí"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "soubor protokolu pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "výchozí hodnota převzatá z konfiguračního souboru pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -116,53 +120,53 @@ msgstr "přidat $pkg mezi ignorované? [a/N] "
 msgid "y"
 msgstr "a"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "místní"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "vzdálený"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Neplatná volba"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nelze downgradovat $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Chybí argument --pacman"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Chybí argument --pacman-conf"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Chybí argument --ala-url"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Chybí argument --pacman-cache"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Chybí argument --pacman-log"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Chybí argument --maxdepth"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nerozpoznaná možnost $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 

--- a/locale/downgrade.pot
+++ b/locale/downgrade.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 11:01+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,11 +41,11 @@ msgid "pacman configuration file, defaults to"
 msgstr ""
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
+msgid "pacman cache directory,"
 msgstr ""
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr ""
 
 #: downgrade:17 downgrade:21
@@ -54,6 +54,10 @@ msgstr ""
 
 #: downgrade:19
 msgid "pacman log file,"
+msgstr ""
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
 msgstr ""
 
 #: downgrade:22
@@ -113,52 +117,52 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr ""
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr ""
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr ""
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr ""
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr ""
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr ""
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr ""
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr ""
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr ""
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr ""
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr ""
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 18:01-0400\n"
 "Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -41,11 +41,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "archivo de configuración de pacman, el valor predeterminado es"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "directorio o directorios de caché pacman,"
+msgid "pacman cache directory,"
+msgstr "directorio de caché pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "valor predeterminado tomado del archivo de configuración de pacman,"
 
 #: downgrade:17 downgrade:21
@@ -55,6 +55,10 @@ msgstr "o por defecto es"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "archivo de registro de pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valor predeterminado tomado del archivo de configuración de pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -116,53 +120,53 @@ msgstr "Añadir $pkg a paquetes ignorados [s/N] "
 msgid "y"
 msgstr "s"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "local"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Elección inválida"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "No se puede degradar $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Falta el argumento --pacman"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Falta el argumento --pacman-conf"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Falta el argumento --ala-url"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Falta el argumento --pacman-cache"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Falta el argumento --pacman-log"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Falta el argumento --maxdepth"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opción no reconocida $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -43,11 +43,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "fichier de configuration pacman, par défaut"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "répertoire ou répertoires de cache pacman,"
+msgid "pacman cache directory,"
+msgstr "répertoire de cache pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "valeur par défaut extraite du fichier de configuration de pacman,"
 
 #: downgrade:17 downgrade:21
@@ -57,6 +57,10 @@ msgstr "ou par défaut"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "fichier journal pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valeur par défaut extraite du fichier de configuration de pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -119,53 +123,53 @@ msgstr ""
 msgid "y"
 msgstr "o"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "local"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "distant"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Choix invalide"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Impossible de rétrograder $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Argument --pacman manquant"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Argument --pacman-conf manquant"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Argument --ala-url manquant"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Argument --pacman-cache manquant"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Argument --pacman-log manquant"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Argument --maxdepth manquant"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Option non reconnue $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"
 

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
 "Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -46,11 +46,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "Pacman konfigūracijos failas, pagal nutylėjimą"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "Pacman talpyklos katalogas arba katalogai,"
+msgid "pacman cache directory,"
+msgstr "Pacman talpyklos katalogas,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "numatytoji vertė, paimta iš pacman konfigūracijos failo,"
 
 #: downgrade:17 downgrade:21
@@ -60,6 +60,10 @@ msgstr "arba kitaip pagal nutylėjimą yra"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "Pacman žurnalo failas"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "numatytoji vertė, paimta iš pacman konfigūracijos failo,"
 
 #: downgrade:22
 msgid "integer"
@@ -119,53 +123,53 @@ msgstr "pridėti $pkg į IgnorePkg? [t/N] "
 msgid "y"
 msgstr "t"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "vietinis"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "nutolęs"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Netinkamas pasirinkimas"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Neįmanoma paversti žemesnio lygio $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Trūksta argumento --pacman"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Trūksta argumento --pacman-conf"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Trūksta argumento --ala-url"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Trūksta argumento --pacman-cache"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Trūksta argumento --pacman-log"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Trūksta argumento --maxdepth"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Neatpažinta parinktis $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -43,11 +43,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "pacman cache-katalog eller kataloger,"
+msgid "pacman cache directory,"
+msgstr "pacman cache-katalog,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "eller på annen måte standard til"
 
 #: downgrade:17 downgrade:21
@@ -57,6 +57,10 @@ msgstr "plassering av ALA-server, er standard til"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "pacman-loggfil"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "eller på annen måte standard til"
 
 #: downgrade:22
 msgid "integer"
@@ -116,53 +120,53 @@ msgstr "legg til $pkg i IgnorePkg? [j/N] "
 msgid "y"
 msgstr "j"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 

--- a/locale/nn.po
+++ b/locale/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -43,11 +43,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman konfigurasjonsfil, er standard til"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "pacman cache-katalog eller kataloger,"
+msgid "pacman cache directory,"
+msgstr "pacman cache-katalog,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "eller på annen måte standard til"
 
 #: downgrade:17 downgrade:21
@@ -57,6 +57,10 @@ msgstr "plassering av ALA-server, er standard til"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "pacman-loggfil"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "eller på annen måte standard til"
 
 #: downgrade:22
 msgid "integer"
@@ -116,53 +120,53 @@ msgstr "legg til $pkg i IgnorePkg? [j/N] "
 msgid "y"
 msgstr "j"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "lokal"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
 "Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -45,11 +45,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "plik konfiguracyjny pacmana, domyślnie"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "katalog lub katalogi pamięci podręcznej pacman,"
+msgid "pacman cache directory,"
+msgstr "katalog pamięci podręcznej pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "wartość domyślna pobrana z pliku konfiguracyjnego pacman,"
 
 #: downgrade:17 downgrade:21
@@ -59,6 +59,10 @@ msgstr "lub w inny sposób domyślnie"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "plik dziennika pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "wartość domyślna pobrana z pliku konfiguracyjnego pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -118,53 +122,53 @@ msgstr "dodać $pkg do IgnorePkg? [t/N] "
 msgid "y"
 msgstr "t"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "lokalnie"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "do pobrania"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nie można obniżyć poziomu $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Brak argumentu --pacman"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Brak argumentu --pacman-conf"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Brak argumentu --ala-url"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Brak argumentu --pacman-cache"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Brak argumentu --pacman-log"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Brak argumentu --maxdepth"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nierozpoznana opcja $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
 "Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
 "atreya@gmail.com>\n"
@@ -44,11 +44,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "arquivo de configuração pacman, o padrão é"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "diretório ou diretórios de cache pacman,"
+msgid "pacman cache directory,"
+msgstr "diretório de cache pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "valor padrão obtido do arquivo de configuração pacman,"
 
 #: downgrade:17 downgrade:21
@@ -58,6 +58,10 @@ msgstr "ou o padrão é"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "arquivo de log pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "valor padrão obtido do arquivo de configuração pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -116,53 +120,53 @@ msgstr "adicionar $pkg em IgnorePkg? [s/N] "
 msgid "y"
 msgstr "s"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "local"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Escolha inválida"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Não foi possível fazer o downgrade $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Argumento --pacman ausente"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Argumento --pacman-conf ausente"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Argumento --ala-url ausente"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Argumento --pacman-cache ausente"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Argumento --pacman-log ausente"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Argumento --maxdepth ausente"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opção não reconhecida $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -45,11 +45,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "Файл конфигурации pacman, по умолчанию"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
-msgstr "каталог или каталоги кэша pacman,"
+msgid "pacman cache directory,"
+msgstr "каталог кеша pacman,"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "значение по умолчанию берется из файла конфигурации pacman,"
 
 #: downgrade:17 downgrade:21
@@ -59,6 +59,10 @@ msgstr "или по умолчанию"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "файл журнала pacman"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "значение по умолчанию берется из файла конфигурации pacman,"
 
 #: downgrade:22
 msgid "integer"
@@ -118,53 +122,53 @@ msgstr "добавить $pkg в список проигнорированных
 msgid "y"
 msgstr "д"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "локально"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "дистанционно"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "Неверный выбор"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Невозможно понизить $name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "Отсутствует аргумент --pacman-conf"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "Отсутствует аргумент --ala-url"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "Отсутствует аргумент --pacman-cache"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "Отсутствует аргумент --pacman-log"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "Отсутствует аргумент --maxdepth"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Нераспознанная опция $current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-29 10:31+0200\n"
+"POT-Creation-Date: 2020-10-22 20:25+0200\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -42,11 +42,11 @@ msgid "pacman configuration file, defaults to"
 msgstr "pacman配置文件，默认为"
 
 #: downgrade:15
-msgid "pacman cache directory or directories,"
+msgid "pacman cache directory,"
 msgstr "pacman缓存目录，"
 
-#: downgrade:16 downgrade:20
-msgid "default value taken from pacman configuration file,"
+#: downgrade:16
+msgid "default value(s) taken from pacman configuration file,"
 msgstr "取自pacman配置文件的默认值，"
 
 #: downgrade:17 downgrade:21
@@ -56,6 +56,10 @@ msgstr "否则默认为"
 #: downgrade:19
 msgid "pacman log file,"
 msgstr "pacman日志文件"
+
+#: downgrade:20
+msgid "default value taken from pacman configuration file,"
+msgstr "取自pacman配置文件的默认值，"
 
 #: downgrade:22
 msgid "integer"
@@ -114,53 +118,53 @@ msgstr "添加$pkg到IgnorePkg? [y/N] "
 msgid "y"
 msgstr "y"
 
-#: downgrade:206
+#: downgrade:211
 msgid "local"
 msgstr "本地"
 
-#: downgrade:208
+#: downgrade:213
 msgid "remote"
 msgstr "远端"
 
-#: downgrade:263
+#: downgrade:268
 msgid "Invalid choice"
 msgstr "选择无效"
 
-#: downgrade:277
+#: downgrade:282
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "无法降级$name"
 
-#: downgrade:333
+#: downgrade:338
 msgid "Missing --pacman argument"
 msgstr "缺少--pacman参数"
 
-#: downgrade:346
+#: downgrade:351
 msgid "Missing --pacman-conf argument"
 msgstr "缺少--pacman-conf参数"
 
-#: downgrade:359
+#: downgrade:364
 msgid "Missing --ala-url argument"
 msgstr "缺少--ala-url参数"
 
-#: downgrade:372
+#: downgrade:377
 msgid "Missing --pacman-cache argument"
 msgstr "缺少--pacman-cache参数"
 
-#: downgrade:385
+#: downgrade:390
 msgid "Missing --pacman-log argument"
 msgstr "缺少--pacman-log参数"
 
-#: downgrade:398
+#: downgrade:403
 msgid "Missing --maxdepth argument"
 msgstr "缺少--maxdepth参数"
 
-#: downgrade:430
+#: downgrade:435
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "无法识别的选项$current_option"
 
-#: downgrade:445
+#: downgrade:450
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"
 

--- a/test/options_sanity/options_sanity.t
+++ b/test/options_sanity/options_sanity.t
@@ -2,7 +2,7 @@
 
 Checking that CLI options match up with environmental variables, packages and pacman options
 
-  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only pkg1 pkg2 -- -Syu; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only pkg1 pkg2 -- -Syu; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "${PACMAN_CACHE[@]}"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}"; unset PACMAN_CACHE; unset terms
   foo
   bar
   bat
@@ -15,7 +15,7 @@ Checking that CLI options match up with environmental variables, packages and pa
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only pkg1 pkg2 -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "${PACMAN_CACHE[@]}"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}"; unset PACMAN_CACHE; unset terms
   foo
   bar
   bat
@@ -28,7 +28,7 @@ Checking that CLI options match up with environmental variables, packages and pa
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --ala-only --nosudo pkg1 pkg2 -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "${PACMAN_CACHE[@]}"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}"; unset PACMAN_CACHE; unset terms
   foo
   bar
   bat
@@ -41,7 +41,7 @@ Checking that CLI options match up with environmental variables, packages and pa
   pkg1 pkg2
   -Syu
 
-  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only --nosudo -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "$PACMAN_CACHE"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}";
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-log /home/test.log --maxdepth 10 --ala-url bat --cached-only --nosudo pkg1 pkg2 -- -Syu 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "$DOWNGRADE_ALA_URL"; echo "${PACMAN_CACHE[@]}"; echo "$PACMAN_LOG"; echo "$DOWNGRADE_MAXDEPTH"; echo "$DOWNGRADE_FROM_ALA"; echo "$DOWNGRADE_FROM_CACHE"; echo "$DOWNGRADE_NOSUDO"; echo "${terms[@]}"; echo "${pacman_args[@]}"; unset PACMAN_CACHE; unset terms
   foo
   bar
   bat
@@ -53,3 +53,9 @@ Checking that CLI options match up with environmental variables, packages and pa
   1
   pkg1 pkg2
   -Syu
+
+  $ parse_options --pacman foo --pacman-conf bar --pacman-cache /home/ --pacman-cache /away/ pkg1 pkg2 2>/dev/null; echo "$PACMAN"; echo "$PACMAN_CONF"; echo "${PACMAN_CACHE[@]}"; echo "${terms[@]}"; unset PACMAN_CACHE; unset terms
+  foo
+  bar
+  /home/ /away/
+  pkg1 pkg2


### PR DESCRIPTION
### Checklist

- [x] Search issues/pull-requests to ensure no duplicates
- [x] Update cram unit tests
- [x] Update `zsh`, `fish` and `bash` shell-completions
- [x] Update mandoc
- [x] Update usage function and readme
- [x] Update locales and add new translations

~- [ ] **Optional:** This might be an extreme edge case. Assume if the same package is present in two different pacman cache locations (maybe because it was an AUR package before and got shifted to one of the official repos later on). Based on local tests, I noticed that `downgrade` now would display the package twice in the menu. This could be solved by showing the location of the cache corresponding to the package in the menu, but I can imagine the menu would look horrible. Another option would be to just show one (unique) package if multiple copies are present. WDYT?~

### Description

This PR addresses #135 by modfying the `PACMAN_CACHE` variable read from stdin into a bash array. This allows us to search multiple cache locations with the `search_packages` function. Based on local tests, it also does not conflict with the case where there is only one pacman configuration location. Try out the following:

```shell
$ downgrade --pacman-cache /path/to/somewhere --pacman-cache /path/to/somewhere/else foo bar
```