### PR TITLE
Add --version command-line option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ AUR_RELEASE_OPTIONS ?=
 .PHONY: release
 release: test
 	[ -n "$(VERSION)" ]
+	sed -E "s/^(DOWNGRADE_VERSION=)(.*)/\1\"v$(VERSION)\"/g" -i downgrade
+	git add downgrade
+	git commit -m "Release v$(VERSION)"
 	git tag -s -m v$(VERSION) v$(VERSION)
 	git push --follow-tags
 	aur-release $(AUR_RELEASE_OPTIONS) downgrade "$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
                   location of ALA server, defaults to "https://archive.archlinux.org"
   --ala-only      only use ALA server
   --cached-only   only use cached packages
+  --version       show downgrade version
   -h, --help      show help script
 
 Note:

--- a/completion/fish
+++ b/completion/fish
@@ -1,15 +1,12 @@
 set -l cmd downgrade
-
 complete -c $cmd -xa "(__fish_print_packages)"
-
-complete -c $cmd -l pacman -xa "(complete -C(commandline -ct))" -d 'pacman command to use, defaults to "pacman"'
-complete -c $cmd -l pacman-conf -r -d 'pacman configuration file, defaults to "/etc/pacman.conf"'
-complete -c $cmd -l pacman-cache -r -d 'pacman cache directory or directories'
+complete -c $cmd -l pacman -xa "(complete -C(commandline -ct))" -d 'pacman command to use'
+complete -c $cmd -l pacman-conf -r -d 'pacman configuration file'
+complete -c $cmd -l pacman-cache -r -d 'pacman cache directory'
 complete -c $cmd -l pacman-log -r -d 'pacman log file'
 complete -c $cmd -l maxdepth -x -d 'maximum depth to search for cached packages'
 complete -c $cmd -l ala-url -x -d 'location of ALA server'
-
 complete -c $cmd -l ala-only -d 'only use ALA server'
 complete -c $cmd -l cached-only -d 'only use cached packages'
-
+complete -c $cmd -l version -d 'show downgrade version'
 complete -c $cmd -s h -l help -d 'show help script'

--- a/completion/zsh
+++ b/completion/zsh
@@ -2,15 +2,16 @@
 
 _downgrade(){
   _arguments -S -C '*:packages:->pkg' \
-             '--pacman[Specify pacman command]:pacman command' \
-             '--pacman-conf[Specify pacman configuration file]:pacman config file:_files' \
-             '*--pacman-cache[Specify pacman cache directory or directories]:pacman cache directory:_path_files -/' \
-             '--pacman-log[Specify pacman log-file]:pacman log file:_files' \
-             '--maxdepth[Specify maximum depth for local cache find]:maximum search depth' \
-             '--ala-url[Specify location of ALA server]:ala url' \
-             '--ala-only[Option enables only ALA server search]' \
-             '--cached-only[Option enables only cached search]' \
-             {-h,--help}'[Show help]'
+             '--pacman[pacman command to use]:pacman command' \
+             '--pacman-conf[pacman configuration file]:pacman config file:_files' \
+             '*--pacman-cache[pacman cache directory]:pacman cache directory:_path_files -/' \
+             '--pacman-log[pacman log file]:pacman log file:_files' \
+             '--maxdepth[maximum depth to search for cached packages]:maximum search depth' \
+             '--ala-url[location of ALA server]:ala url' \
+             '--ala-only[only use ALA server]' \
+             '--cached-only[only use cached packages]' \
+             '--version[show downgrade version]' \
+             {-h,--help}'[show help script]'
 
   if [[ $state == "pkg" ]] && [[ ! $words =~ "\s\-\-\s" ]]; then
     local -a packages

--- a/doc/downgrade.8
+++ b/doc/downgrade.8
@@ -133,6 +133,24 @@ Search ALA only.
 .PP
 Search local cache only.
 .RE
+.PP
+\f[B]--version\f[R]
+.PD 0
+.P
+.PD
+.RS
+.PP
+Show downgrade version.
+.RE
+.PP
+\f[B]-h, --help\f[R]
+.PD 0
+.P
+.PD
+.RS
+.PP
+Show help script.
+.RE
 .SS CONFIGURATION FILE
 .PP
 Command-line options can be set persistently in

--- a/doc/downgrade.8.md
+++ b/doc/downgrade.8.md
@@ -87,6 +87,14 @@ on the ALA.
 
 > Search local cache only.
 
+**\--version**\
+
+> Show downgrade version.
+
+**\-h, \--help**\
+
+> Show help script.
+
 ## CONFIGURATION FILE
 
 Command-line options can be set persistently in **/etc/xdg/downgrade.conf**.

--- a/downgrade
+++ b/downgrade
@@ -486,6 +486,9 @@ if ((!LIB)); then
     if [[ "$arg" =~ ^-h$|^--help$ ]]; then
       usage
       exit 0
+    elif [[ "$arg" == '--version' ]]; then
+      printf "%s\n" "$DOWNGRADE_VERSION"
+      exit 0
     fi
   done
 

--- a/downgrade
+++ b/downgrade
@@ -25,6 +25,7 @@ $(gettext "Options"):
                   $(gettext "location of ALA server, defaults to") "https://archive.archlinux.org"
   --ala-only      $(gettext "only use ALA server")
   --cached-only   $(gettext "only use cached packages")
+  --version       $(gettext "show downgrade version")
   -h, --help      $(gettext "show help script")
 
 $(gettext "Note"):

--- a/downgrade
+++ b/downgrade
@@ -464,6 +464,7 @@ DOWNGRADE_FROM_ALA=1
 DOWNGRADE_FROM_CACHE=1
 DOWNGRADE_MAXDEPTH=1
 DOWNGRADE_CONF="/etc/xdg/downgrade/downgrade.conf"
+DOWNGRADE_VERSION="v10.0.0"
 
 # Main code execution
 if ((!LIB)); then

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -84,85 +84,89 @@ msgid "only use cached packages"
 msgstr "používejte pouze balíčky v mezipaměti"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "zobrazit downgrade verzi"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "zobrazit skript nápovědy"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Poznámka"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Možnosti za znaky -- budou považovány za možnosti pacmanu."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Pro více informací vizte downgrade(8)"
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Dostupné balíčky"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "vyberte balíček číslem: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "přidat $pkg mezi ignorované? [a/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "a"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "vzdálený"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Neplatná volba"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nelze downgradovat $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Chybí argument --pacman"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Chybí argument --pacman-conf"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Chybí argument --ala-url"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Chybí argument --pacman-cache"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Chybí argument --pacman-log"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Chybí argument --maxdepth"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nerozpoznaná možnost $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade musí být spuštěn jako root"
 

--- a/locale/downgrade.pot
+++ b/locale/downgrade.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,84 +81,88 @@ msgid "only use cached packages"
 msgstr ""
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr ""
+
+#: downgrade:29
 msgid "show help script"
 msgstr ""
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr ""
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr ""
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr ""
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr ""
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr ""
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr ""
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr ""
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr ""
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr ""
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr ""
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr ""
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr ""
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr ""
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr ""
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr ""
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr ""
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr ""
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr ""

--- a/locale/es.po
+++ b/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 18:01-0400\n"
 "Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -82,87 +82,91 @@ msgid "only use cached packages"
 msgstr "solo use paquetes en caché"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "mostrar la versión downgrade"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "mostrar guión de ayuda"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Las opciones después de los caracteres -- se tratarán como opciones de "
 "pacman."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Ver downgrade(8) para más detalles."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Paquetes disponibles"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "Selecciona un paquete por su número: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "Añadir $pkg a paquetes ignorados [s/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "s"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Elección inválida"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "No se puede degradar $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Falta el argumento --pacman"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Falta el argumento --pacman-conf"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Falta el argumento --ala-url"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Falta el argumento --pacman-cache"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Falta el argumento --pacman-log"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Falta el argumento --maxdepth"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opción no reconocida $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade debe ejecutarse como root"
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -84,88 +84,92 @@ msgid "only use cached packages"
 msgstr "utiliser uniquement des packages mis en cache"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "afficher la version downgrade"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "afficher le script d'aide"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Remarque"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Les options après les caractères -- seront traitées comme des options pacman."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Voir downgrade(8) pour plus de détails."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Paquets disponibles"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "Sélectionner le paquet numéro : "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr ""
 "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
 "automatiquement ? [o/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "o"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "distant"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Choix invalide"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Impossible de rétrograder $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Argument --pacman manquant"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Argument --pacman-conf manquant"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Argument --ala-url manquant"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Argument --pacman-cache manquant"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Argument --pacman-log manquant"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Argument --maxdepth manquant"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Option non reconnue $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "le downgrade doit être exécuté en tant que root"
 

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
 "Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -87,85 +87,89 @@ msgid "only use cached packages"
 msgstr "naudokite tik talpykloje laikomus paketus"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "rodyti downgrade versiją"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "rodyti pagalbos scenarijų"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Pastaba"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Parinktys po simbolių -- bus traktuojamos kaip pacman parinktys."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Išsamiau galite paskaityti downgrade(8)."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Prieinami paketai"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "įveskite paketo numerį:"
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "pridėti $pkg į IgnorePkg? [t/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "t"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "nutolęs"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Netinkamas pasirinkimas"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Neįmanoma paversti žemesnio lygio $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Trūksta argumento --pacman"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Trūksta argumento --pacman-conf"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Trūksta argumento --ala-url"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Trūksta argumento --pacman-cache"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Trūksta argumento --pacman-log"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Trūksta argumento --maxdepth"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Neatpažinta parinktis $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade turi būti paleistas kaip root"
 

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -83,86 +83,90 @@ msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "vis downgrade versjonen"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Se downgrade(8) for detaljer."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Tilgjengelige pakker"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "velg en pakke ved nummer: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "j"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade må kjøres som root"
 

--- a/locale/nn.po
+++ b/locale/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
 "Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
 "com>\n"
@@ -83,86 +83,90 @@ msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "vis downgrade versjonen"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Merk"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Sjå downgrade(8) for detaljar."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Tilgjengelege pakkar"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "vel ei pakke ved nummer: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "j"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "ekstern"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade må kjøres som root"
 

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
 "Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -86,85 +86,89 @@ msgid "only use cached packages"
 msgstr "używaj tylko pakietów buforowanych"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "pokaż downgrade wersję"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "pokaż skrypt pomocy"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Uwaga"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Opcje po znakach -- będą traktowane jako opcje Pacman."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Zobacz downgrade(8) po szczegóły."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Dostępne pakiety"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "wybierz pakiet według numeru: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "dodać $pkg do IgnorePkg? [t/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "t"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "do pobrania"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nie można obniżyć poziomu $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Brak argumentu --pacman"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Brak argumentu --pacman-conf"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Brak argumentu --ala-url"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Brak argumentu --pacman-cache"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Brak argumentu --pacman-log"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Brak argumentu --maxdepth"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nierozpoznana opcja $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade musi być uruchamiany jako root"
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
 "Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
 "atreya@gmail.com>\n"
@@ -84,85 +84,89 @@ msgid "only use cached packages"
 msgstr "use apenas pacotes em cache"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "mostrar a versão downgrade"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "mostrar script de ajuda"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Nota"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "As opções após os caracteres -- serão tratadas como opções do pacman."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "Veja downgrade(8) para mais detalhes."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Pacotes disponíveis"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "selecione um pacote por número:"
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "adicionar $pkg em IgnorePkg? [s/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "s"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "remoto"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Escolha inválida"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Não foi possível fazer o downgrade $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Argumento --pacman ausente"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Argumento --pacman-conf ausente"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Argumento --ala-url ausente"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Argumento --pacman-cache ausente"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Argumento --pacman-log ausente"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Argumento --maxdepth ausente"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opção não reconhecida $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade deve ser executado como root"
 

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -85,86 +85,90 @@ msgid "only use cached packages"
 msgstr "использовать только кэшированные пакеты"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "показать версию downgrade"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "показать скрипт помощи"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "Заметка"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Параметры после символов -- будут рассматриваться как параметры pacman."
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "см. downgrade(8) для подробностей."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "Доступные пакеты"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "выберите пакет по номеру: "
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/Н] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "д"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "дистанционно"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "Неверный выбор"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Невозможно понизить $name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "Отсутствует аргумент --pacman-conf"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "Отсутствует аргумент --ala-url"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "Отсутствует аргумент --pacman-cache"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "Отсутствует аргумент --pacman-log"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "Отсутствует аргумент --maxdepth"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Нераспознанная опция $current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade должен запускаться как root"
 

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-19 13:43+0200\n"
+"POT-Creation-Date: 2021-05-21 11:58+0200\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -82,85 +82,89 @@ msgid "only use cached packages"
 msgstr "只使用缓存的包"
 
 #: downgrade:28
+msgid "show downgrade version"
+msgstr "显示downgrade版本"
+
+#: downgrade:29
 msgid "show help script"
 msgstr "显示帮助脚本"
 
-#: downgrade:30
+#: downgrade:31
 msgid "Note"
 msgstr "注意"
 
-#: downgrade:31
+#: downgrade:32
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "--字符后的选项将被视为pacman选项。"
 
-#: downgrade:32
+#: downgrade:33
 msgid "See downgrade(8) for details."
 msgstr "详情请查看downgrade(8)."
 
-#: downgrade:84
+#: downgrade:85
 msgid "Available packages"
 msgstr "可选的包"
 
-#: downgrade:94
+#: downgrade:95
 msgid "select a package by number: "
 msgstr "输入数字以选择包："
 
-#: downgrade:111
+#: downgrade:112
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "添加$pkg到IgnorePkg? [y/N] "
 
-#: downgrade:114
+#: downgrade:115
 msgid "y"
 msgstr "y"
 
-#: downgrade:231
+#: downgrade:232
 msgid "remote"
 msgstr "远端"
 
-#: downgrade:285
+#: downgrade:286
 msgid "Invalid choice"
 msgstr "选择无效"
 
-#: downgrade:299
+#: downgrade:300
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "无法降级$name"
 
-#: downgrade:328
+#: downgrade:329
 msgid "Missing --pacman argument"
 msgstr "缺少--pacman参数"
 
-#: downgrade:341
+#: downgrade:342
 msgid "Missing --pacman-conf argument"
 msgstr "缺少--pacman-conf参数"
 
-#: downgrade:354
+#: downgrade:355
 msgid "Missing --ala-url argument"
 msgstr "缺少--ala-url参数"
 
-#: downgrade:367
+#: downgrade:368
 msgid "Missing --pacman-cache argument"
 msgstr "缺少--pacman-cache参数"
 
-#: downgrade:380
+#: downgrade:381
 msgid "Missing --pacman-log argument"
 msgstr "缺少--pacman-log参数"
 
-#: downgrade:393
+#: downgrade:394
 msgid "Missing --maxdepth argument"
 msgstr "缺少--maxdepth参数"
 
-#: downgrade:418
+#: downgrade:419
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "无法识别的选项$current_option"
 
-#: downgrade:433
+#: downgrade:434
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"
 
-#: downgrade:495
+#: downgrade:500
 msgid "downgrade must be run as root"
 msgstr "downgrade必须以root身份运行"
 


### PR DESCRIPTION
### Checklist

- [x] Search issues/pull-requests to ensure no duplicates
- [x] Update cram unit tests
- [x] Update `zsh`, `fish` and `bash` shell-completions
- [x] Update mandoc
- [x] Update usage function and readme
- [x] Update locales and add new translations

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it and write a few words next to the task as to why that task is not relevant to your pull request -->

### Description

This PR addresses #147 by proposing a new `--version` command-line option. This prints out the `DOWNGRADE_VERSION` variable that is defined internally.

I chose to forego the whole process with `m4` as it seemed bulky compared to the simple regular-expression based replacement that is required for this. Also I am sure we will never define the `DOWNGRADE_VERSION` variable in any other context in `downgrade`, so the absolute replacement using `sed` should be safe.

WDYT?

<!-- Describe your pull request and mention any issue(s) that it might be linked to -->