### PR TITLE
Release v10.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 - [ ] Update readme
 - [ ] Update locales
 - [ ] Update change log, if releasing
+- [ ] Update `DOWNGRADE_VERSION`, if releasing
 
 <!-- These are likely side tasks that would need to be completed before merging the pull request -->
 <!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,6 @@ AUR_RELEASE_OPTIONS ?=
 .PHONY: release
 release: test
 	[ -n "$(VERSION)" ]
-	sed -E "s/^(DOWNGRADE_VERSION=)(.*)/\1\"v$(VERSION)\"/g" -i downgrade
-	git add downgrade
-	git commit -m "Release v$(VERSION)"
 	git tag -s -m v$(VERSION) v$(VERSION)
 	git push --follow-tags
 	aur-release $(AUR_RELEASE_OPTIONS) downgrade "$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -55,18 +55,7 @@ uninstall:
 	  $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/downgrade.fish \
 	  $(DESTDIR)$(LOCALEPREFIX)/*/LC_MESSAGES/downgrade.mo
 
-.PHONY: release.major
-release.major: VERSION=$(shell git tag | vbump major | sed 's/^v//')
-release.major: release
-
-.PHONY: release.minor
-release.minor: VERSION=$(shell git tag | vbump minor | sed 's/^v//')
-release.minor: release
-
-.PHONY: release.patch
-release.patch: VERSION=$(shell git tag | vbump patch | sed 's/^v//')
-release.patch: release
-
+VERSION ?= $(shell sed '/^DOWNGRADE_VERSION="\([^"]*\)".*$$/!d; s//\1/' downgrade)
 AUR_RELEASE_OPTIONS ?=
 
 .PHONY: release

--- a/downgrade
+++ b/downgrade
@@ -468,7 +468,7 @@ DOWNGRADE_FROM_ALA=1
 DOWNGRADE_FROM_CACHE=1
 DOWNGRADE_MAXDEPTH=1
 DOWNGRADE_CONF="/etc/xdg/downgrade/downgrade.conf"
-DOWNGRADE_VERSION="v10.0.0"
+DOWNGRADE_VERSION="v10.1.0"
 
 # Main code execution
 if ((!LIB)); then


### PR DESCRIPTION
### Checklist

- [x] No duplicate issues/PRs
- [x] Update usage function
- [x] Update unit tests
- [x] Update shell completions
- [x] Update mandoc
- [x] Update readme
- [x] Update locales
- [x] Update change log, if releasing

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

### Description

Changes are as follows:

1. Remove feature in `Makefile` which updates `DOWNGRADE_VERSION` automatically, since this results in branch protection problems
2. Add the task of updating `DOWNGRADE_VERSION` manually to GitHub PR templates
3. Update `DOWNGRADE_VERSION` to `v10.1.0` for this minor version bump and release