### PR TITLE
Patch test in `term_operator_version_parsing.t`

### DIFF
--- a/test/main/term_operator_version_parsing.t
+++ b/test/main/term_operator_version_parsing.t
@@ -6,15 +6,17 @@ Check if package name, operator and version can be separated
   $ touch "$TMP/foo.pkg"
   > search_packages() { printf "%s\n" "$TMP/foo.pkg"; }
   > filter_packages() { echo "$*" >&2; cat; }
-  > main "foo=1.0.0-1" "foo==1.0.0-1" "bar<=1.0.0-1" 
-  > main "baz>=1.0.0-1" "bat<1.0.0-1" "bam>1.0.0-1"
+  > main "foo=1.0.0-1" "foo==1.0.0-1" "foo=~^1.0"
+  > main "bar<=1.0.0-1" "baz>=1.0.0-1" "bat<1.0.0-1" "bam>1.0.0-1"
   > printf "ignore: %s\n" "${to_ignore[@]}"
   foo = 1.0.0-1
   foo == 1.0.0-1
+  foo =~ ^1.0
   bar <= 1.0.0-1
   baz >= 1.0.0-1
   bat < 1.0.0-1
   bam > 1.0.0-1
+  ignore: foo
   ignore: foo
   ignore: foo
   ignore: bar


### PR DESCRIPTION
### Checklist

- [x] No duplicate issues/PRs
- [x] Update usage function
- [x] Update unit tests
- [x] Update shell completions
- [x] Update mandoc
- [x] Update readme
- [x] Update locales
- [x] Update change log, if releasing
- [x] Update `DOWNGRADE_VERSION`, if releasing

<!-- These are likely side tasks that would need to be completed before merging the pull request -->
<!-- If a task is not relevant to your pull request, tick it nonetheless and skip to the next task(s) -->

### Description

A test for the `=~` operator was missing, so just updating it with this PR.