### PR TITLE
fix: avoid empty-string argument when config is empty

### DIFF
--- a/src/downgrade
+++ b/src/downgrade
@@ -56,8 +56,16 @@ read_pacman_conf() {
 
 read_downgrade_conf() {
   local var=$1
+  local raw
 
-  eval "$var=($(grep -E -v '^ *(#.*)?$' "$DOWNGRADE_CONF" 2>/dev/null | xargs printf '%q '))"
+  raw=$(grep -E -v '^ *(#.*)?$' "$DOWNGRADE_CONF" 2>/dev/null)
+
+  if [[ -z "$raw" ]]; then
+    # no real lines
+    eval "$var=()"
+  else
+    eval "$var=( $(printf '%q ' $raw) )"
+  fi
 }
 
 read_unique() {


### PR DESCRIPTION
### Checklist

* Admin:
  - [x] No duplicate PRs

### Description

In newer versions of Bash (e.g., 5.2+), the following construct:

```bash
some_array=( $printf '%q ' $raw)
```

produces an array with a single empty string element (`("")`) when $raw is empty, whereas older versions (e.g., Bash 5.1 and earlier) would produce an empty array (`()`).

I'm not sure if this is actually Bash's fault, but the problem is real and the fix works (at least from my testing)