### PR TITLE
fix: migrate legacy `__fish_print_packages` (which is broken now)

### DIFF
--- a/dist/completion/downgrade/fish
+++ b/dist/completion/downgrade/fish
@@ -1,5 +1,5 @@
 set -l cmd downgrade
-complete -c $cmd -xa "(__fish_print_packages)"
+complete -c $cmd -xa "(__fish_print_pacman_packages)"
 complete -c $cmd -l pacman -xa "(complete -C(commandline -ct))" -d 'pacman command to use'
 complete -c $cmd -l pacman-conf -r -d 'pacman configuration file'
 complete -c $cmd -l pacman-cache -r -d 'pacman cache directory'


### PR DESCRIPTION
fix: migrate legacy `__fish_print_packages` (which is broken now) to `__fish_print_pacman_packages`

> ```fish
>     # This is `__fish_print_packages`. It prints packages,
>     # from the first package manager it finds.
>     # That's a pretty bad idea, which is why this is broken up,
>     # and only available for legacy reasons.
> ```