### PR TITLE
Feat aur automatic fallback

### DIFF
--- a/dist/completion/downgrade/fish
+++ b/dist/completion/downgrade/fish
@@ -4,7 +4,6 @@ complete -c $cmd -l pacman -xa "(complete -C(commandline -ct))" -d 'pacman comma
 complete -c $cmd -l pacman-conf -r -d 'pacman configuration file'
 complete -c $cmd -l pacman-cache -r -d 'pacman cache directory'
 complete -c $cmd -l pacman-log -r -d 'pacman log file'
-complete -c $cmd -l git -d 'uses git for choosing version, viable only for aur packages'
 complete -c $cmd -l maxdepth -x -d 'maximum depth to search for cached packages'
 complete -c $cmd -l ala-url -x -d 'location of ALA server'
 complete -c $cmd -l ala-only -d 'only use ALA server'

--- a/dist/completion/downgrade/zsh
+++ b/dist/completion/downgrade/zsh
@@ -20,7 +20,6 @@ _downgrade () {
     '--pacman-conf[pacman configuration file]:pacman config file:_files' \
     '*--pacman-cache[pacman cache directory]:pacman cache directory:_path_files -/' \
     '--pacman-log[pacman log file]:pacman log file:_files' \
-    '--git[uses git for choosing version, viable only for aur packages]' \
     '--maxdepth[maximum depth to search for cached packages]:maximum search depth' \
     '--ala-url[location of ALA server]:ala url' \
     '--ala-only[only use ALA server]' \

--- a/doc/downgrade.8.ronn
+++ b/doc/downgrade.8.ronn
@@ -72,17 +72,8 @@ on the ALA.
     Pacman log file, default value is extracted from pacman configuration file, or
     otherwise defaults to _/var/log/pacman.log_.
 
-  * `--git`:
-    If the pacman cache contains the source repository for the package (e.g. if
-    you use yay and are downgrading an AUR package), present any version-like
-    tags as available for downgrading (together with cached packages if
-    present). If selected, build and install the package from sources checked
-    out at that tag.
-
-    See [EXAMPLES].
-
   * `--maxdepth`=<INTEGER>:
-    Maximum depth to search for cached packages, defaults to _1_.
+    Maximum depth to search for cached packages, defaults to _2_.
 
   * `--ala-url`=<URL>:
     Location of an ALA server, default is *https://archive.archlinux.org*.
@@ -122,7 +113,9 @@ sequence will be treated as pacman options.
 
 ## DEFAULT BEHAVIORS
 
-By default, **downgrade** will search both local caches and the ALA.
+By default, **downgrade** will search both local caches and the ALA. AUR helper
+cache directories (_~/.cache/yay_, _~/.cache/paru/clone_) are automatically
+included if present, so AUR packages are found without extra configuration.
 
 If only one package with its corresponding location matches, the package will be
 installed without further prompt from the user.
@@ -177,10 +170,10 @@ Non-interactively downgrade `foo` to `1.0.0-1`
 
     # downgrade --latest --prefer-cache --ignore never 'foo=1.0.0-1'
 
-Present cached `downgrade` pkgbuilds together with tags with version greater
-than 9
+Downgrade an AUR package with version-filtering (git versions are shown
+automatically when a git repo is found in the cache):
 
-    # downgrade --git --pacman-cache ~/.cache/yay --maxdepth 2 'downgrade>9.0.0'
+    # downgrade 'downgrade>9.0.0'
 
 ## AUTHORS
 

--- a/locale/downgrade/cs.po
+++ b/locale/downgrade/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 21:10+0100\n"
 "Last-Translator: <tom.vycital@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -63,137 +63,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "výchozí hodnota převzatá z konfiguračního souboru pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "celé číslo"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr ""
 "maximální hloubka pro vyhledávání balíčků v mezipaměti, výchozí hodnota"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "umístění serveru ALA, výchozí nastavení je"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "používejte pouze server ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "používejte pouze balíčky v mezipaměti"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "přidat $pkg mezi ignorované? [a/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "přidat $pkg mezi ignorované? [a/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "zobrazit downgrade verzi"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "zobrazit skript nápovědy"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Poznámka"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Možnosti za znaky -- budou považovány za možnosti pacmanu."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Pro více informací vizte downgrade(8)"
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Dostupné balíčky"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "a"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "přidat $pkg mezi ignorované? [a/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "vzdálený"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Nebyly nalezeny žádné výsledky"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Neplatná volba"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nelze downgradovat $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Chybí argument --pacman"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Chybí argument --pacman-conf"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Chybí argument --ala-url"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Chybí argument --pacman-cache"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Chybí argument --pacman-log"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Chybí argument --maxdepth"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Chybí argument --pacman"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nerozpoznaná možnost $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Pro downgradování nebyly poskytnuty žádné balíčky"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade musí být spuštěn jako root"
 

--- a/locale/downgrade/es.po
+++ b/locale/downgrade/es.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
-"PO-Revision-Date: 2020-04-21 18:01-0400\n"
-"Last-Translator: <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
+"PO-Revision-Date: 2026-02-18 12:41-0700\n"
+"Last-Translator: <stronger6@gmail.com>, <miachm3@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -61,139 +61,147 @@ msgid "default value taken from pacman configuration file,"
 msgstr "valor predeterminado tomado del archivo de configuración de pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr "usa git para elegir la versión, solo viable para paquetes AUR"
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "entero"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr ""
 "profundidad máxima para buscar paquetes en caché, el valor predeterminado es"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "ubicación del servidor ALA, el valor predeterminado es"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "solo use el servidor ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "solo use paquetes en caché"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "Añadir $pkg a paquetes ignorados [s/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "Añadir $pkg a paquetes ignorados [s/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "mostrar la versión downgrade"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "mostrar guión de ayuda"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Nota"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Las opciones después de los caracteres -- se tratarán como opciones de "
 "pacman."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr "Los directorios de caché de yay y paru se buscan automáticamente si están presentes."
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Ver downgrade(8) para más detalles."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Paquetes disponibles"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "s"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "Añadir $pkg a paquetes ignorados [s/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "remoto"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "No se han encontrado resultados"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Elección inválida"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "No se puede degradar $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Falta el argumento --pacman"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Falta el argumento --pacman-conf"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Falta el argumento --ala-url"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Falta el argumento --pacman-cache"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Falta el argumento --pacman-log"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Falta el argumento --maxdepth"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Falta el argumento --pacman"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opción no reconocida $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "No se proporcionan paquetes para degradar"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade debe ejecutarse como root"
 

--- a/locale/downgrade/fr.po
+++ b/locale/downgrade/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 12:56-0400\n"
 "Last-Translator: <jagw40k@free.fr>, <shankar.atreya@gmail.com>\n"
 "Language-Team: French\n"
@@ -63,144 +63,152 @@ msgid "default value taken from pacman configuration file,"
 msgstr "valeur par défaut extraite du fichier de configuration de pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "entier"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr ""
 "profondeur maximale pour rechercher les packages mis en cache, par défaut"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "emplacement du serveur ALA, par défaut"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "utiliser uniquement le serveur ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "utiliser uniquement des packages mis en cache"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr ""
 "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
 "automatiquement ? [o/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr ""
 "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
 "automatiquement ? [o/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "afficher la version downgrade"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "afficher le script d'aide"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Remarque"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Les options après les caractères -- seront traitées comme des options pacman."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Voir downgrade(8) pour plus de détails."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Paquets disponibles"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "o"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr ""
 "Ajouter $pkg dans la liste des paquets à ne pas mettre à jour "
 "automatiquement ? [o/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "distant"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Choix invalide"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Impossible de rétrograder $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Argument --pacman manquant"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Argument --pacman-conf manquant"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Argument --ala-url manquant"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Argument --pacman-cache manquant"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Argument --pacman-log manquant"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Argument --maxdepth manquant"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Argument --pacman manquant"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Option non reconnue $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Aucun package fourni pour la rétrogradation"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "le downgrade doit être exécuté en tant que root"
 

--- a/locale/downgrade/lt.po
+++ b/locale/downgrade/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 13:53+0200\n"
 "Last-Translator: Algimantas Margevičius <margevicius.algimantas@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -66,137 +66,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "numatytoji vertė, paimta iš pacman konfigūracijos failo,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "sveikasis skaičius"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr ""
 "maksimalus gylis ieškant talpykloje esančių paketų, numatytasis reikšmė yra"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "ALA serverio vieta, numatytoji reikšmė"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "naudoti tik ALA serverį"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "naudokite tik talpykloje laikomus paketus"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "pridėti $pkg į IgnorePkg? [t/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "pridėti $pkg į IgnorePkg? [t/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "rodyti downgrade versiją"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "rodyti pagalbos scenarijų"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Pastaba"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Parinktys po simbolių -- bus traktuojamos kaip pacman parinktys."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Išsamiau galite paskaityti downgrade(8)."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Prieinami paketai"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "t"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "pridėti $pkg į IgnorePkg? [t/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "nutolęs"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Nieko nerasta"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Netinkamas pasirinkimas"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Neįmanoma paversti žemesnio lygio $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Trūksta argumento --pacman"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Trūksta argumento --pacman-conf"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Trūksta argumento --ala-url"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Trūksta argumento --pacman-cache"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Trūksta argumento --pacman-log"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Trūksta argumento --maxdepth"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Trūksta argumento --pacman"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Neatpažinta parinktis $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Nepateikta jokių pakuočių, leidžiančių pažengti žemiau"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade turi būti paleistas kaip root"
 

--- a/locale/downgrade/nb.po
+++ b/locale/downgrade/nb.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
-"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
-"com>\n"
+"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, "
+"<shankar.atreya@gmail.com>\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
@@ -63,137 +63,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "eller på annen måte standard til"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "heltall"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr "maksimal dybde for å søke etter hurtigbufrede pakker, som standard"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "vis downgrade versjonen"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Merk"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Se downgrade(8) for detaljer."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Tilgjengelige pakker"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "j"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "ekstern"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Ingen resultater"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade må kjøres som root"
 

--- a/locale/downgrade/nn.po
+++ b/locale/downgrade/nn.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 12:48-0400\n"
-"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, <shankar.atreya@gmail."
-"com>\n"
+"Last-Translator: Håkon Vågsether <hauk142@gmail.com>, "
+"<shankar.atreya@gmail.com>\n"
 "Language-Team: Norwegian Nynorsk\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
@@ -63,137 +63,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "eller på annen måte standard til"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "heltall"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr "maksimal dybde for å søke etter hurtigbufrede pakker, som standard"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "plassering av ALA-server, er standard til"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "bruk bare ALA-serveren"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "bruk bare hurtigbufrede pakker"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "vis downgrade versjonen"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "vis hjelpeskript"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Merk"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Alternativer etter -- tegnene vil bli behandlet som pacman-alternativer."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Sjå downgrade(8) for detaljar."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Tilgjengelege pakkar"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "j"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "legg til $pkg i IgnorePkg? [j/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "ekstern"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Ingen resultater"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Ugyldig valg"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Kan ikke nedgradere $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Mangler --pacman-conf -argumentet"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Mangler --ala-url -argumentet"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Mangler --pacman-cache -argumentet"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Mangler --pacman-log -argumentet"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Mangler --maxdepth -argumentet"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Mangler --pacman -argumentet"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Ukjent alternativ $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Ingen pakker gitt for nedgradering"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade må kjøres som root"
 

--- a/locale/downgrade/pl.po
+++ b/locale/downgrade/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 17:23+0200\n"
 "Last-Translator: Tomasz \"Ludvick\" Niedzielski <ludvick0@gmail.com>, "
 "<shankar.atreya@gmail.com>\n"
@@ -65,137 +65,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "wartość domyślna pobrana z pliku konfiguracyjnego pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "liczba całkowita"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr ""
 "maksymalna głębokość do wyszukiwania pakietów w pamięci podręcznej, domyślnie"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "lokalizacja serwera ALA, domyślnie"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "używaj tylko serwera ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "używaj tylko pakietów buforowanych"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "dodać $pkg do IgnorePkg? [t/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "dodać $pkg do IgnorePkg? [t/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "pokaż downgrade wersję"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "pokaż skrypt pomocy"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Uwaga"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "Opcje po znakach -- będą traktowane jako opcje Pacman."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Zobacz downgrade(8) po szczegóły."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Dostępne pakiety"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "t"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "dodać $pkg do IgnorePkg? [t/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "do pobrania"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Nie znaleziono wyników"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Nieprawidłowy wybór"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Nie można obniżyć poziomu $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Brak argumentu --pacman"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Brak argumentu --pacman-conf"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Brak argumentu --ala-url"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Brak argumentu --pacman-cache"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Brak argumentu --pacman-log"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Brak argumentu --maxdepth"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Brak argumentu --pacman"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Nierozpoznana opcja $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Brak pakietów do obniżenia"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade musi być uruchamiany jako root"
 

--- a/locale/downgrade/pt_BR.po
+++ b/locale/downgrade/pt_BR.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 01:23-0300\n"
-"Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, <shankar."
-"atreya@gmail.com>\n"
+"Last-Translator: Thiago Perrotta <thiagoperrotta95@gmail.com>, "
+"<shankar.atreya@gmail.com>\n"
 "Language-Team: Portuguese (Brazilian)\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -64,136 +64,144 @@ msgid "default value taken from pacman configuration file,"
 msgstr "valor padrão obtido do arquivo de configuração pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "inteiro"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr "profundidade máxima para procurar pacotes em cache, o padrão é"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "localização do servidor ALA, o padrão é"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "use apenas o servidor ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "use apenas pacotes em cache"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "adicionar $pkg à lista IgnorePkg? [s/N] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "remover $pkg da lista IgnorePkg? [s/N] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr "escolha a versão mais recente de correspondência"
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr "escolha a versão mais antiga de correspondência"
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr "não consulte Ala se um pacote correspondente foi encontrado em cache"
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "mostrar a versão downgrade"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "mostrar script de ajuda"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Nota"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "As opções após os caracteres -- serão tratadas como opções do pacman."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "Veja downgrade(8) para mais detalhes."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Pacotes disponíveis"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "s"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "adicionar $pkg em IgnorePkg? [s/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "remoto"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Escolha inválida"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Não foi possível fazer o downgrade $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Argumento --pacman ausente"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Argumento --pacman-conf ausente"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Argumento --ala-url ausente"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Argumento --pacman-cache ausente"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Argumento --pacman-log ausente"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Argumento --maxdepth ausente"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Argumento --pacman ausente"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Opção não reconhecida $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Nenhum pacote fornecido para desatualização"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade deve ser executado como root"
 

--- a/locale/downgrade/ru.po
+++ b/locale/downgrade/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 14:25-0300\n"
 "Last-Translator: Nurlan <nurlancik1@gmail.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -65,137 +65,145 @@ msgid "default value taken from pacman configuration file,"
 msgstr "значение по умолчанию берется из файла конфигурации pacman,"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "целое число"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr "максимальная глубина для поиска в кэшированных пакетах, по умолчанию"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "расположение сервера ALA, по умолчанию"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "использовать только сервер ALA"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "использовать только кэшированные пакеты"
 
-#: src/downgrade:29
+#: src/downgrade:30
 #, fuzzy
 msgid "whether to add packages to IgnorePkg"
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/Н] "
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/Н] "
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "показать версию downgrade"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "показать скрипт помощи"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "Заметка"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr ""
 "Параметры после символов -- будут рассматриваться как параметры pacman."
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "см. downgrade(8) для подробностей."
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "Доступные пакеты"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "д"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "добавить $pkg в список проигнорированных пакетов? [д/Н] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "дистанционно"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "результаты не найдены"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "Неверный выбор"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "Невозможно понизить $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "Отсутствует аргумент --pacman-conf"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "Отсутствует аргумент --ala-url"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "Отсутствует аргумент --pacman-cache"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "Отсутствует аргумент --pacman-log"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "Отсутствует аргумент --maxdepth"
 
-#: src/downgrade:470
+#: src/downgrade:540
 #, fuzzy
 msgid "Missing or wrong --ignore argument"
 msgstr "Отсутствует аргумент --pacman"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "Нераспознанная опция $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "Нет пакетов для понижения"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade должен запускаться как root"
 

--- a/locale/downgrade/zh_CN.po
+++ b/locale/downgrade/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: downgrade\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-22 12:44-0400\n"
+"POT-Creation-Date: 2026-02-18 12:41-0700\n"
 "PO-Revision-Date: 2020-04-21 23:16+0800\n"
 "Last-Translator:  <weih@opera.com>, <shankar.atreya@gmail.com>\n"
 "Language-Team: Chinese\n"
@@ -62,134 +62,142 @@ msgid "default value taken from pacman configuration file,"
 msgstr "取自 pacman 配置文件的默认值，"
 
 #: src/downgrade:22
+msgid "uses git for choosing version, viable only for aur packages"
+msgstr ""
+
+#: src/downgrade:23
 msgid "integer"
 msgstr "整数"
 
-#: src/downgrade:23
+#: src/downgrade:24
 msgid "maximum depth to search for cached packages, defaults to"
 msgstr "搜索缓存包的最大深度，默认为"
 
-#: src/downgrade:25
+#: src/downgrade:26
 msgid "location of ALA server, defaults to"
 msgstr "ALA 服务器的位置，默认为"
 
-#: src/downgrade:26
+#: src/downgrade:27
 msgid "only use ALA server"
 msgstr "仅使用 ALA 服务器"
 
-#: src/downgrade:27
+#: src/downgrade:28
 msgid "only use cached packages"
 msgstr "只使用缓存的包"
 
-#: src/downgrade:29
+#: src/downgrade:30
 msgid "whether to add packages to IgnorePkg"
 msgstr "是否添加软件包到 IgnorePkg"
 
-#: src/downgrade:30
+#: src/downgrade:31
 #, fuzzy
 msgid "remove packages from IgnorePkg"
 msgstr "是否添加软件包到 IgnorePkg"
 
-#: src/downgrade:31
+#: src/downgrade:32
 msgid "pick latest matching version"
 msgstr ""
 
-#: src/downgrade:32
+#: src/downgrade:33
 msgid "pick oldest matching version"
 msgstr ""
 
-#: src/downgrade:33
+#: src/downgrade:34
 msgid "do not query ala if a matching package was found in cache"
 msgstr ""
 
-#: src/downgrade:34
+#: src/downgrade:35
 msgid "show downgrade version"
 msgstr "显示 downgrade 版本"
 
-#: src/downgrade:35
+#: src/downgrade:36
 msgid "show help script"
 msgstr "显示帮助脚本"
 
-#: src/downgrade:37
+#: src/downgrade:38
 msgid "Note"
 msgstr "注意"
 
-#: src/downgrade:38
+#: src/downgrade:39
 msgid "Options after the -- characters will be treated as pacman options."
 msgstr "-- 字符后的选项将被视为 pacman 选项。"
 
-#: src/downgrade:39
+#: src/downgrade:40
+msgid "yay and paru cache directories are searched automatically if present."
+msgstr ""
+
+#: src/downgrade:41
 msgid "See downgrade(8) for details."
 msgstr "详情请查看 downgrade(8)。"
 
-#: src/downgrade:103
+#: src/downgrade:127
 msgid "Available packages"
 msgstr "可选的包"
 
-#: src/downgrade:124
+#: src/downgrade:148
 msgid "y"
 msgstr "y"
 
-#: src/downgrade:143
+#: src/downgrade:167
 #, sh-format
 msgid "add $pkg to IgnorePkg? [y/N] "
 msgstr "添加 $pkg 到 IgnorePkg? [y/N] "
 
-#: src/downgrade:265
+#: src/downgrade:327
 msgid "remote"
 msgstr "远端"
 
-#: src/downgrade:325
+#: src/downgrade:392
 msgid "No results found"
 msgstr "未找到结果"
 
-#: src/downgrade:342
+#: src/downgrade:409
 msgid "Invalid choice"
 msgstr "选择无效"
 
-#: src/downgrade:355
+#: src/downgrade:422
 #, sh-format
 msgid "Unable to downgrade $name"
 msgstr "无法降级 $name"
 
-#: src/downgrade:384
+#: src/downgrade:451
 msgid "Missing --pacman argument"
 msgstr "缺少 --pacman 参数"
 
-#: src/downgrade:397
+#: src/downgrade:464
 msgid "Missing --pacman-conf argument"
 msgstr "缺少 --pacman-conf 参数"
 
-#: src/downgrade:410
+#: src/downgrade:477
 msgid "Missing --ala-url argument"
 msgstr "缺少 --ala-url 参数"
 
-#: src/downgrade:423
+#: src/downgrade:490
 msgid "Missing --pacman-cache argument"
 msgstr "缺少 --pacman-cache 参数"
 
-#: src/downgrade:436
+#: src/downgrade:503
 msgid "Missing --pacman-log argument"
 msgstr "缺少 --pacman-log 参数"
 
-#: src/downgrade:449
+#: src/downgrade:519
 msgid "Missing --maxdepth argument"
 msgstr "缺少 --maxdepth 参数"
 
-#: src/downgrade:470
+#: src/downgrade:540
 msgid "Missing or wrong --ignore argument"
 msgstr "--pacman 参数缺失或有误"
 
-#: src/downgrade:503
+#: src/downgrade:573
 #, sh-format
 msgid "Unrecognized option $current_option"
 msgstr "无法识别的选项 $current_option"
 
-#: src/downgrade:518
+#: src/downgrade:588
 msgid "No packages provided for downgrading"
 msgstr "没有提供降级包"
 
-#: src/downgrade:588
+#: src/downgrade:695
 msgid "downgrade must be run as root"
 msgstr "downgrade 必须以 root 身份运行"
 

--- a/src/downgrade
+++ b/src/downgrade
@@ -19,9 +19,8 @@ $(gettext "Options"):
                   $(gettext "pacman log file,")
                   $(gettext "default value taken from pacman configuration file,")
                   $(gettext "or otherwise defaults to") "/var/log/pacman.log"
-  --git           $(gettext "uses git for choosing version, viable only for aur packages")
   --maxdepth      <$(gettext "integer")>
-                  $(gettext "maximum depth to search for cached packages, defaults to") 1
+                  $(gettext "maximum depth to search for cached packages, defaults to") 2
   --ala-url       <url>
                   $(gettext "location of ALA server, defaults to") "https://archive.archlinux.org"
   --ala-only      $(gettext "only use ALA server")
@@ -37,6 +36,7 @@ $(gettext "Options"):
 
 $(gettext "Note"):
   $(gettext "Options after the -- characters will be treated as pacman options.")
+  $(gettext "yay and paru cache directories are searched automatically if present.")
   $(gettext "See downgrade(8) for details.")
 EOF
 }
@@ -80,6 +80,24 @@ previously_installed() {
     /.*\(installed\|upgraded\) \('"$1"'\) (\(.* -> \)\?\([^)]*\))/!d
     s//\2-\4/
   ' "$PACMAN_LOG"
+}
+
+get_real_user_home() {
+  local user=${SUDO_USER:-$USER}
+
+  if [[ -n "$user" ]]; then
+    getent passwd "$user" | cut -d: -f6
+  fi
+}
+
+detect_aur_caches() {
+  local home
+  home=$(get_real_user_home)
+
+  [[ -z "$home" ]] && return 0
+
+  [[ -d "$home/.cache/yay" ]] && printf '%s\n' "$home/.cache/yay"
+  [[ -d "$home/.cache/paru/clone" ]] && printf '%s\n' "$home/.cache/paru/clone"
 }
 
 currently_installed() {
@@ -168,8 +186,8 @@ matches_name_version_filter() {
     return 0
   fi
 
-  # version: 2025.11.12.r15.g0eed3fe
-  version_regex="[a-zA-Z0-9._]+"
+  # version: 1:2025.11.12.r15.g0eed3fe
+  version_regex="[a-zA-Z0-9._:]+"
   hash_or_minor="([0-9]+|[a-z0-9]{6,})"
   pkg_version=$(sed -r "s/.*$name-($version_regex)(-$hash_or_minor)?-(any|$DOWNGRADE_ARCH)\\.(git)?pkg\\.tar\\.(gz|xz|zst)/\1\2/g" <<<"$pkg")
   cmp=$(vercmp "$pkg_version" "$search_version")
@@ -199,34 +217,6 @@ matches_name_version_filter() {
   esac
 }
 
-search_git() {
-  local name=$1 pairs path
-
-  # Delay this defaulting so #read_pacman_conf behavior is tested
-  if ((!${#PACMAN_CACHE[@]})); then
-    mapfile -t PACMAN_CACHE < <(read_pacman_conf CacheDir)
-  fi
-
-  for cache in "${PACMAN_CACHE[@]}"; do
-    path="$cache/$name" # directory name
-    if ! [[ -d "$path/.git" ]]; then
-      {
-        gettext "\`$path\" not a git directory, skipping..."
-        echo
-      } >&2
-      continue
-    fi
-
-    # TODO: in future could be enhanced by counting every commit
-    # that DOES NOT change version as minor like 0.0.1-2 instead of any
-    # pair = abcd12 1.0
-    pairs=$(git -C "$path" log -p --oneline --format="GIT: %h" PKGBUILD | grep -e 'GIT:.*' -e '+pkgver' | grep -Pzo 'GIT: .*\n\+pkgver=.*\n' | sed 's/GIT: \|+pkgver=//' | tr -d '\0')
-
-    # shellcheck disable=SC2086
-    echo "$path/$name" $pairs | awk '{for(i=2;i<NF;i+=2) printf "%s-%s-%s-any.gitpkg.tar.gz\n", $1, $(i+1), $i}' | sort -V
-  done
-}
-
 search_ala() {
   local name=$1 uriname pkgfile_re index
 
@@ -248,8 +238,8 @@ search_ala() {
 search_cache() {
   local name=$1 pkgfile_re index
 
-  # version: 2025.11.12.r15.g0eed3fe
-  version_regex="[a-zA-Z0-9._]+"
+  # version: 1:2025.11.12.r15.g0eed3fe
+  version_regex="[a-zA-Z0-9._:]+"
   hash_or_minor="([0-9]+|[a-z0-9]{6,})"
   pkgfile_re="$name-($version_regex)(-$hash_or_minor)?-(any|$DOWNGRADE_ARCH)\\.pkg\\.tar\\.(gz|xz|zst)"
 
@@ -264,6 +254,27 @@ search_cache() {
 
   # shellcheck disable=SC2086
   find -L "${PACMAN_CACHE[@]}" -maxdepth "$DOWNGRADE_MAXDEPTH" -regextype posix-extended -regex ".*/$pkgfile_re"
+
+  # Search git history in AUR cache directories
+  local pairs path epoch_prefix
+  for cache in "${PACMAN_CACHE[@]}"; do
+    path="$cache/$name"
+    [[ -d "$path/.git" ]] || continue
+
+    # Use current epoch from PKGBUILD if present
+    epoch_prefix=""
+    local epoch
+    epoch=$(git -C "$path" show HEAD:PKGBUILD 2>/dev/null | sed -n "s/^epoch=//p" | tr -d "'\"")
+    [[ -n "$epoch" ]] && epoch_prefix="${epoch}:"
+
+    # TODO: in future could be enhanced by counting every commit
+    # that DOES NOT change version as minor like 0.0.1-2 instead of any
+    # pair = abcd12 1.0
+    pairs=$(git -C "$path" log -p --oneline --format="GIT: %h" PKGBUILD | grep -e 'GIT:.*' -e '+pkgver' | grep -Pzo 'GIT: .*\n\+pkgver=.*\n' | sed "s/GIT: \|+pkgver=//;s/['\"]//g" | tr -d '\0')
+
+    # shellcheck disable=SC2086
+    echo "$path/$name" $pairs | awk -v ep="$epoch_prefix" '{for(i=2;i<NF;i+=2) printf "%s-%s%s-%s-any.gitpkg.tar.gz\n", $1, ep, $(i+1), $i}' | sort -V
+  done
 }
 
 sort_packages() {
@@ -344,6 +355,13 @@ process_term() {
   installed=($(previously_installed "$name"))
   current=$(currently_installed "$name")
 
+  if ((!${#PACMAN_CACHE[@]})); then
+    mapfile -t PACMAN_CACHE < <(
+      read_pacman_conf CacheDir
+      detect_aur_caches
+    )
+  fi
+
   candidates=()
   if ((DOWNGRADE_FROM_CACHE)); then
     candidates+=($(search_cache "$name" | filter_packages "$name" "$operator" "$version"))
@@ -353,11 +371,6 @@ process_term() {
   fi
 
   candidates=($(printf '%s\n' "${candidates[@]}" | sort_packages))
-
-  # this is already sorted
-  if ((DOWNGRADE_FROM_GIT)); then
-    candidates=($(search_git "$name" | filter_packages "$name" "$operator" "$version") "${candidates[@]}")
-  fi
 
   if (("${#candidates[@]}" == 0)); then
     {
@@ -479,9 +492,6 @@ parse_options() {
           exit 1
         fi
         ;;
-      --git)
-        DOWNGRADE_FROM_GIT=1
-        ;;
       --maxdepth)
         if [[ -n "$2" ]]; then
           shift
@@ -569,7 +579,7 @@ build_pkg() {
   local item="$1" path commit_hash build_failed versionreg hashreg gitpkgreg
   if [[ "$item" =~ .*gitpkg.tar.gz ]]; then
     # version: 2025.11.12.r15.g0eed3fe
-    versionreg="([a-zA-Z0-9_]+\.?)*"
+    versionreg="([a-zA-Z0-9_:]+\.?)*"
     hashreg='[a-z0-9]{6,}'
     #hash_or_minor="-([0-9]+|[a-z0-9]{6,})" # leaving this as a note, only hash should appear tho
     gitpkgreg="(.*)-$versionreg-($hashreg)-(any|$DOWNGRADE_ARCH).gitpkg.tar.gz"
@@ -609,10 +619,10 @@ cli() {
 
   # Proceed with rest of workflow
   main "${terms[@]}"
-  if ((DOWNGRADE_FROM_GIT)); then
-    for item in "${to_install[@]}"; do
-      build_pkg "$item"
-    done
+  for item in "${to_install[@]}"; do
+    build_pkg "$item"
+  done
+  if [[ -f new_to_install.downgrade ]]; then
     mapfile -d '' to_install <new_to_install.downgrade
     rm new_to_install.downgrade
   fi
@@ -626,10 +636,9 @@ PACMAN="pacman"
 PACMAN_CONF="/etc/pacman.conf"
 DOWNGRADE_ARCH="$(pacman-conf Architecture | head -n 1)"
 DOWNGRADE_ALA_URL="https://archive.archlinux.org"
-DOWNGRADE_FROM_GIT=0
 DOWNGRADE_FROM_ALA=1
 DOWNGRADE_FROM_CACHE=1
-DOWNGRADE_MAXDEPTH=1
+DOWNGRADE_MAXDEPTH=2
 DOWNGRADE_CONF="/etc/xdg/downgrade/downgrade.conf"
 DOWNGRADE_VERSION="__VERSION__"
 DOWNGRADE_IGNORE="prompt"

--- a/test/aur_fallback/detect_aur_caches.t
+++ b/test/aur_fallback/detect_aur_caches.t
@@ -1,0 +1,44 @@
+  $ source "$TESTDIR/../helper.sh"
+  > PACMAN_LOG=/dev/null
+
+Detects yay cache when present
+
+  $ fake_home=$(mktemp -d)
+  > mkdir -p "$fake_home/.cache/yay"
+  > get_real_user_home() { echo "$fake_home"; }
+  > detect_aur_caches
+  /tmp/*/yay (glob)
+  [1]
+
+Detects paru cache when present
+
+  $ fake_home=$(mktemp -d)
+  > mkdir -p "$fake_home/.cache/paru/clone"
+  > get_real_user_home() { echo "$fake_home"; }
+  > detect_aur_caches
+  /tmp/*/paru/clone (glob)
+
+Detects both when both present
+
+  $ fake_home=$(mktemp -d)
+  > mkdir -p "$fake_home/.cache/yay"
+  > mkdir -p "$fake_home/.cache/paru/clone"
+  > get_real_user_home() { echo "$fake_home"; }
+  > detect_aur_caches
+  /tmp/*/yay (glob)
+  /tmp/*/paru/clone (glob)
+
+Returns nothing when neither present
+
+  $ fake_home=$(mktemp -d)
+  > get_real_user_home() { echo "$fake_home"; }
+  > result=$(detect_aur_caches)
+  > test -z "$result" && echo "empty"
+  empty
+
+Returns nothing when home is empty
+
+  $ get_real_user_home() { :; }
+  > result=$(detect_aur_caches)
+  > test -z "$result" && echo "empty"
+  empty

--- a/test/aur_fallback/search_cache_aur.t
+++ b/test/aur_fallback/search_cache_aur.t
@@ -1,0 +1,29 @@
+  $ source "$TESTDIR/../helper.sh"
+  > PACMAN_LOG=/dev/null
+
+search_cache finds packages in AUR helper cache directories
+
+  $ aur_cache=$(mktemp -d)
+  > mkdir -p "$aur_cache/foo"
+  > touch "$aur_cache/foo/foo-1.0-1-x86_64.pkg.tar.zst"
+  > DOWNGRADE_FROM_CACHE=1
+  > DOWNGRADE_MAXDEPTH=2
+  > DOWNGRADE_ARCH=x86_64
+  > PACMAN_CACHE=("$aur_cache")
+  > search_cache 'foo' | sort
+  /tmp/*/foo/foo-1.0-1-x86_64.pkg.tar.zst (glob)
+
+search_cache finds packages in both regular and AUR caches
+
+  $ regular_cache=$(mktemp -d)
+  > aur_cache=$(mktemp -d)
+  > touch "$regular_cache/foo-2.0-1-any.pkg.tar.gz"
+  > mkdir -p "$aur_cache/foo"
+  > touch "$aur_cache/foo/foo-1.0-1-x86_64.pkg.tar.zst"
+  > DOWNGRADE_FROM_CACHE=1
+  > DOWNGRADE_MAXDEPTH=2
+  > DOWNGRADE_ARCH=x86_64
+  > PACMAN_CACHE=("$regular_cache" "$aur_cache")
+  > search_cache 'foo' | xargs -n1 basename | sort
+  foo-1.0-1-x86_64.pkg.tar.zst
+  foo-2.0-1-any.pkg.tar.gz

--- a/test/search_git.t
+++ b/test/search_git.t
@@ -2,15 +2,14 @@
   > cache=$(mktemp -d)
   > git clone -q "https://aur.archlinux.org/downgrade.git" "$cache/downgrade"
   > write_pacman_conf "[options]" "CacheDir = $cache"
-  > export DOWNGRADE_FROM_GIT=1
 
 List packages based on git tags
 
-  $ search_git 'downgrade' | head -n 2
+  $ search_cache 'downgrade' | head -n 2
   /tmp/*/downgrade-5.1.3-0bdb507-any.gitpkg.tar.gz (glob)
   /tmp/*/downgrade-5.1.4-dee7bd9-any.gitpkg.tar.gz (glob)
 
 Outputs appropriately for filter_packages
 
-  $ search_git 'downgrade' | filter_packages 'downgrade' '=~' '^7' | head -n 1
+  $ search_cache 'downgrade' | filter_packages 'downgrade' '=~' '^7' | head -n 1
   /tmp/*/downgrade-7.0.0-513f504-any.gitpkg.tar.gz (glob)


### PR DESCRIPTION
### Checklist

* Admin:
  - [X] No duplicate PRs
* Integration:
  - [X] Always add unit tests for fixes or new functionality
* Documentation:
  - [X] If adding new options, update usage and `doc/*.ronn`
  - [X] If adding new strings, update `locale/*.po`

### Description

Add new feature; automatically falling back to AUR git downgrading when package is foreign to pacman.
Equivalent to manually passing `--git --pacman-cache ~/.cache/yay --maxdepth 2` if `pacman -Qm` returns 0 on a package.
Automatically checks for yay and paru in their default dirs to find git repos for downgrading.