### PR TITLE
chore(docs): tweak release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
+            conventional-changelog-conventionalcommits
             @semantic-release/exec
         env:
           FORCE_COLOR: 1

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,6 +1,8 @@
 plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/commit-analyzer"
+    - preset: "conventionalcommits"
+  - - "@semantic-release/release-notes-generator"
+    - preset: "conventionalcommits"
   - - "@semantic-release/github"
     - assets: "downgrade-*.tar.gz"
       successCommentCondition: false

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ prefix in your commit message:
 
 [conventional-commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
 
-1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. `feat!:` to trigger major
+1. Use `fix:` to trigger a patch release
+1. Use `feat:` to trigger minor
+1. Use `<type>!:` or add a `BREAKING CHANGE` trailer to trigger major
 
 When such a commit is merged to `main`, a new GitHub release will be created and
 a `PKGBUILD` update will be [published automatically][aur-publish-action].


### PR DESCRIPTION
### chore(release): add conventional-commits plugin

da00cd5fed9a6ec3151b38658c2105f1220b7aa7

The default (angular) only supports `BREAKING CHANGE` and not the
`<type>!` syntax, which we'd prefer to use.

### chore(docs): tweak release docs

cab5da3d7a603336a399bc483c4af981075d5b33
