### PR TITLE
fix: check for XDG_CACHE_HOME

### DIFF
--- a/src/downgrade
+++ b/src/downgrade
@@ -91,13 +91,13 @@ get_real_user_home() {
 }
 
 detect_aur_caches() {
-  local home
-  home=$(get_real_user_home)
+  local cache_home
+  cache_home="${XDG_CACHE_HOME:-$(get_real_user_home)/.cache}"
 
-  [[ -z "$home" ]] && return 0
+  [[ -z "$cache_home" ]] && return 0
 
-  [[ -d "$home/.cache/yay" ]] && printf '%s\n' "$home/.cache/yay"
-  [[ -d "$home/.cache/paru/clone" ]] && printf '%s\n' "$home/.cache/paru/clone"
+  [[ -d "$cache_home/yay" ]] && printf '%s\n' "$cache_home/yay"
+  [[ -d "$cache_home/paru/clone" ]] && printf '%s\n' "$cache_home/paru/clone"
 }
 
 currently_installed() {

--- a/test/aur_fallback/detect_aur_caches.t
+++ b/test/aur_fallback/detect_aur_caches.t
@@ -1,6 +1,5 @@
   $ source "$TESTDIR/../helper.sh"
   > PACMAN_LOG=/dev/null
-  $ unset XDG_CACHE_HOME
 
 Detects yay cache when present
 

--- a/test/aur_fallback/detect_aur_caches.t
+++ b/test/aur_fallback/detect_aur_caches.t
@@ -41,9 +41,6 @@ Detects both when both present, with xdg taking precedence
   > detect_aur_caches
   /tmp/*@xdg/yay (glob)
   /tmp/*@xdg/paru/clone (glob)
-Unset so doesnt get used by other tests
-  $ unset XDG_CACHE_HOME
-
 
 Returns nothing when neither present
 

--- a/test/aur_fallback/detect_aur_caches.t
+++ b/test/aur_fallback/detect_aur_caches.t
@@ -1,5 +1,6 @@
   $ source "$TESTDIR/../helper.sh"
   > PACMAN_LOG=/dev/null
+  $ unset XDG_CACHE_HOME
 
 Detects yay cache when present
 
@@ -27,6 +28,23 @@ Detects both when both present
   > detect_aur_caches
   /tmp/*/yay (glob)
   /tmp/*/paru/clone (glob)
+
+Detects both when both present, with xdg taking precedence
+
+  $ fake_home=$(mktemp -d --suffix @home)
+  $ fake_xdg=$(mktemp -d --suffix @xdg)
+  > XDG_CACHE_HOME="$fake_xdg"
+  > mkdir -p "$fake_xdg/yay"
+  > mkdir -p "$fake_xdg/paru/clone"
+  > mkdir -p "$fake_home/.cache/yay"
+  > mkdir -p "$fake_home/.cache/paru/clone"
+  > get_real_user_home() { echo "$fake_home"; }
+  > detect_aur_caches
+  /tmp/*@xdg/yay (glob)
+  /tmp/*@xdg/paru/clone (glob)
+Unset so doesnt get used by other tests
+  $ unset XDG_CACHE_HOME
+
 
 Returns nothing when neither present
 

--- a/test/aur_fallback/detect_aur_caches.t
+++ b/test/aur_fallback/detect_aur_caches.t
@@ -39,6 +39,7 @@ Detects both when both present, with xdg taking precedence
   > mkdir -p "$fake_home/.cache/paru/clone"
   > get_real_user_home() { echo "$fake_home"; }
   > detect_aur_caches
+  > XDG_CACHE_HOME=
   /tmp/*@xdg/yay (glob)
   /tmp/*@xdg/paru/clone (glob)
 

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -21,6 +21,7 @@ export DOWNGRADE_FROM_ALA=0
 export DOWNGRADE_FROM_CACHE=0
 export DOWNGRADE_CONF="$SRCDIR/test/conf/downgrade_test.conf"
 export PACIGNORE_DEFAULT_CHECK=1
+export XDG_CACHE_HOME=""
 
 # Stub functions that won't work (on CI) or need different behavior.
 pacsort() { cat; }


### PR DESCRIPTION
### Checklist

* Admin:
  - [X] No duplicate PRs
* Integration:
  - [x] Always add unit tests for fixes or new functionality

### Description

Currently, if the user is using $XDG_CACHE_HOME which differs from $HOME/.cache, downgrade doesn't find anything
This makes it check both by default
(I've never worked with unit tests before so rather than mess up, set pr to draft)
